### PR TITLE
Add ordered retention issue backlog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,3 +17,21 @@ When you are asked to make repository changes, follow this sequence unless the u
 - Do not rewrite unrelated files.
 - Prefer small, reviewable commits.
 - Summarise the checks you ran in the final response.
+
+## Ordered issue queue for retention and delight work
+
+When a user says "implement the next issue", inspect the lists below, pick the first item in `TODO`, implement it, and then move it to `Completed` once the work has landed.
+
+### TODO
+
+1. [#32 Add persistent progression state for retention features](https://github.com/Bigalan09/Burohame/issues/32)
+2. [#33 Add coins as a persistent soft currency](https://github.com/Bigalan09/Burohame/issues/33)
+3. [#34 Add a post-run rewards summary](https://github.com/Bigalan09/Burohame/issues/34)
+4. [#35 Add daily missions with coin rewards](https://github.com/Bigalan09/Burohame/issues/35)
+5. [#36 Add a cosmetics collection and unlock flow](https://github.com/Bigalan09/Burohame/issues/36)
+6. [#37 Add delight feedback for milestone moments](https://github.com/Bigalan09/Burohame/issues/37)
+7. [#38 Add a daily challenge and streak system](https://github.com/Bigalan09/Burohame/issues/38)
+
+### Completed
+
+- None yet.


### PR DESCRIPTION
## Summary
- create a short, ordered set of GitHub issues for the retention and delight roadmap
- update `AGENTS.md` with a `TODO` queue and `Completed` section so future agents can implement the next issue in order
- keep the queue aligned with the new GitHub issue numbers for easy handoff

## Issues created
- #32 Add persistent progression state for retention features
- #33 Add coins as a persistent soft currency
- #34 Add a post-run rewards summary
- #35 Add daily missions with coin rewards
- #36 Add a cosmetics collection and unlock flow
- #37 Add delight feedback for milestone moments
- #38 Add a daily challenge and streak system

## Checks
- `gh issue list --repo Bigalan09/Burohame --limit 10 --state open --json number,title,url`
- `git diff --check`
- `git push -u origin codex/retention-issue-backlog`
