### PR TITLE
Add persistent progression state scaffolding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,14 +24,13 @@ When a user says "implement the next issue", inspect the lists below, pick the f
 
 ### TODO
 
-1. [#32 Add persistent progression state for retention features](https://github.com/Bigalan09/Burohame/issues/32)
-2. [#33 Add coins as a persistent soft currency](https://github.com/Bigalan09/Burohame/issues/33)
-3. [#34 Add a post-run rewards summary](https://github.com/Bigalan09/Burohame/issues/34)
-4. [#35 Add daily missions with coin rewards](https://github.com/Bigalan09/Burohame/issues/35)
-5. [#36 Add a cosmetics collection and unlock flow](https://github.com/Bigalan09/Burohame/issues/36)
-6. [#37 Add delight feedback for milestone moments](https://github.com/Bigalan09/Burohame/issues/37)
-7. [#38 Add a daily challenge and streak system](https://github.com/Bigalan09/Burohame/issues/38)
+1. [#33 Add coins as a persistent soft currency](https://github.com/Bigalan09/Burohame/issues/33)
+2. [#34 Add a post-run rewards summary](https://github.com/Bigalan09/Burohame/issues/34)
+3. [#35 Add daily missions with coin rewards](https://github.com/Bigalan09/Burohame/issues/35)
+4. [#36 Add a cosmetics collection and unlock flow](https://github.com/Bigalan09/Burohame/issues/36)
+5. [#37 Add delight feedback for milestone moments](https://github.com/Bigalan09/Burohame/issues/37)
+6. [#38 Add a daily challenge and streak system](https://github.com/Bigalan09/Burohame/issues/38)
 
 ### Completed
 
-- None yet.
+- [#32 Add persistent progression state for retention features](https://github.com/Bigalan09/Burohame/issues/32)

--- a/app.js
+++ b/app.js
@@ -177,8 +177,126 @@ let extendedPieces = false;
 let darkMode     = false;
 let colorSetting = 'orange';   // 'orange','blue','green','purple','red','teal','pink','random'
 let rackSize     = 3;          // number of pieces shown in the rack (1–3)
+let progressionState = null;
 
 const COLOR_NAMES = ['orange','blue','green','purple','red','teal','pink'];
+const PROGRESSION_STORAGE_KEY = 'bst-progression';
+const PROGRESSION_STATE_VERSION = 1;
+
+function clampWholeNumber(value, fallback) {
+  return Number.isInteger(value) && value >= 0 ? value : fallback;
+}
+
+function uniqueStringList(value, fallback) {
+  if (!Array.isArray(value)) return fallback.slice();
+  return [...new Set(value.filter(item => typeof item === 'string' && item.trim() !== ''))];
+}
+
+function createDefaultProgressionState() {
+  return {
+    version: PROGRESSION_STATE_VERSION,
+    coins: {
+      balance: 0,
+      lifetimeEarned: 0,
+      lifetimeSpent: 0,
+    },
+    unlocks: {
+      equippedTheme: 'classic',
+      ownedThemes: ['classic'],
+      seenRewardIds: [],
+    },
+    dailyMissions: {
+      date: '',
+      missions: [],
+      completedIds: [],
+      claimedIds: [],
+      refreshCount: 0,
+    },
+    streak: {
+      current: 0,
+      best: 0,
+      lastActiveDate: '',
+      lastRewardDate: '',
+      freezes: 0,
+    },
+  };
+}
+
+function sanitiseMissionState(value) {
+  const src = value && typeof value === 'object' ? value : {};
+  return {
+    date: typeof src.date === 'string' ? src.date : '',
+    missions: Array.isArray(src.missions) ? src.missions : [],
+    completedIds: uniqueStringList(src.completedIds, []),
+    claimedIds: uniqueStringList(src.claimedIds, []),
+    refreshCount: clampWholeNumber(src.refreshCount, 0),
+  };
+}
+
+function sanitiseProgressionState(rawState) {
+  const defaults = createDefaultProgressionState();
+  const src = rawState && typeof rawState === 'object' ? rawState : {};
+  const coins = src.coins && typeof src.coins === 'object' ? src.coins : {};
+  const unlocks = src.unlocks && typeof src.unlocks === 'object' ? src.unlocks : {};
+  const streak = src.streak && typeof src.streak === 'object' ? src.streak : {};
+  const ownedThemes = (() => {
+    const owned = uniqueStringList(unlocks.ownedThemes, defaults.unlocks.ownedThemes);
+    return owned.includes('classic') ? owned : ['classic', ...owned];
+  })();
+  const equippedTheme = typeof unlocks.equippedTheme === 'string' && unlocks.equippedTheme.trim() !== ''
+    ? unlocks.equippedTheme
+    : defaults.unlocks.equippedTheme;
+
+  return {
+    version: PROGRESSION_STATE_VERSION,
+    coins: {
+      balance: clampWholeNumber(coins.balance, defaults.coins.balance),
+      lifetimeEarned: clampWholeNumber(coins.lifetimeEarned, defaults.coins.lifetimeEarned),
+      lifetimeSpent: clampWholeNumber(coins.lifetimeSpent, defaults.coins.lifetimeSpent),
+    },
+    unlocks: {
+      equippedTheme: ownedThemes.includes(equippedTheme) ? equippedTheme : defaults.unlocks.equippedTheme,
+      ownedThemes,
+      seenRewardIds: uniqueStringList(unlocks.seenRewardIds, defaults.unlocks.seenRewardIds),
+    },
+    dailyMissions: sanitiseMissionState(src.dailyMissions),
+    streak: {
+      current: clampWholeNumber(streak.current, defaults.streak.current),
+      best: clampWholeNumber(streak.best, defaults.streak.best),
+      lastActiveDate: typeof streak.lastActiveDate === 'string' ? streak.lastActiveDate : '',
+      lastRewardDate: typeof streak.lastRewardDate === 'string' ? streak.lastRewardDate : '',
+      freezes: clampWholeNumber(streak.freezes, defaults.streak.freezes),
+    },
+  };
+}
+
+function saveProgressionState() {
+  localStorage.setItem(PROGRESSION_STORAGE_KEY, JSON.stringify(progressionState));
+}
+
+function loadProgressionState() {
+  try {
+    const raw = JSON.parse(localStorage.getItem(PROGRESSION_STORAGE_KEY) || 'null');
+    progressionState = sanitiseProgressionState(raw);
+  } catch (_) {
+    progressionState = createDefaultProgressionState();
+  }
+
+  saveProgressionState();
+}
+
+function updateProgressionState(updater) {
+  const draft = sanitiseProgressionState(progressionState);
+  const next = typeof updater === 'function' ? updater(draft) : draft;
+  progressionState = sanitiseProgressionState(next || draft);
+  saveProgressionState();
+  return progressionState;
+}
+
+function resetProgressionState() {
+  progressionState = createDefaultProgressionState();
+  saveProgressionState();
+}
 
 // ── Piece helpers ──────────────────────────────────────────
 function bounds(cells) {
@@ -1362,6 +1480,8 @@ document.getElementById('btn-clear-data').addEventListener('click', async () => 
   localStorage.removeItem('bst-best');
   localStorage.removeItem('bst-today');
   localStorage.removeItem('bst-settings');
+  localStorage.removeItem(PROGRESSION_STORAGE_KEY);
+  progressionState = createDefaultProgressionState();
 
   // Unregister service workers so new assets are fetched on next load
   if ('serviceWorker' in navigator) {
@@ -1398,6 +1518,7 @@ function init() {
   const td   = JSON.parse(localStorage.getItem('bst-today') || '{"d":"","s":0}');
   todayScore = (td.d === todayKey) ? td.s : 0;
 
+  loadProgressionState();
   loadSettings();
   applyDarkMode(darkMode);
   applyColor(colorSetting);


### PR DESCRIPTION
### Motivation

- Prepare a single, versioned local storage model for future retention features such as coins, missions, unlocks and streaks so progression data can be persisted safely across releases.

### Description

- Add a `bst-progression` storage key and constants `PROGRESSION_STORAGE_KEY` and `PROGRESSION_STATE_VERSION` in `app.js` to version progression data.
- Implement sanitising and helper functions: `createDefaultProgressionState`, `sanitiseProgressionState`, `sanitiseMissionState`, `saveProgressionState`, `loadProgressionState`, `updateProgressionState` and `resetProgressionState` to handle missing, partial or corrupt data robustly.
- Wire progression initialisation into the startup flow via `loadProgressionState()` and ensure the Clear Data action also removes and resets the new progression key.
- Update `AGENTS.md` ordered queue to mark issue `#32` as completed so the next queued task is `#33`.

### Testing

- Ran JavaScript syntax check with `node --check app.js` which passed successfully. 
- Ran the static-site validation script with `sh ./scripts/validate-static-site.sh` which completed successfully. 
- Executed a Node-based exercise that loaded, sanitised, migrated and recovered from corrupt progression JSON using a small VM harness (`node /tmp/check_progression_state.js`) and it reported that the progression helpers behave as expected.

All automated checks listed above passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bef8e4b6a483339bda83af5207c0dc)