### PR TITLE
Add persistent coin rewards (issue #33)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,13 +24,13 @@ When a user says "implement the next issue", inspect the lists below, pick the f
 
 ### TODO
 
-1. [#33 Add coins as a persistent soft currency](https://github.com/Bigalan09/Burohame/issues/33)
-2. [#34 Add a post-run rewards summary](https://github.com/Bigalan09/Burohame/issues/34)
-3. [#35 Add daily missions with coin rewards](https://github.com/Bigalan09/Burohame/issues/35)
-4. [#36 Add a cosmetics collection and unlock flow](https://github.com/Bigalan09/Burohame/issues/36)
-5. [#37 Add delight feedback for milestone moments](https://github.com/Bigalan09/Burohame/issues/37)
-6. [#38 Add a daily challenge and streak system](https://github.com/Bigalan09/Burohame/issues/38)
+1. [#34 Add a post-run rewards summary](https://github.com/Bigalan09/Burohame/issues/34)
+2. [#35 Add daily missions with coin rewards](https://github.com/Bigalan09/Burohame/issues/35)
+3. [#36 Add a cosmetics collection and unlock flow](https://github.com/Bigalan09/Burohame/issues/36)
+4. [#37 Add delight feedback for milestone moments](https://github.com/Bigalan09/Burohame/issues/37)
+5. [#38 Add a daily challenge and streak system](https://github.com/Bigalan09/Burohame/issues/38)
 
 ### Completed
 
+- [#33 Add coins as a persistent soft currency](https://github.com/Bigalan09/Burohame/issues/33)
 - [#32 Add persistent progression state for retention features](https://github.com/Bigalan09/Burohame/issues/32)

--- a/app.js
+++ b/app.js
@@ -178,10 +178,20 @@ let darkMode     = false;
 let colorSetting = 'orange';   // 'orange','blue','green','purple','red','teal','pink','random'
 let rackSize     = 3;          // number of pieces shown in the rack (1–3)
 let progressionState = null;
+let coinToastOffset = 0;
 
 const COLOR_NAMES = ['orange','blue','green','purple','red','teal','pink'];
 const PROGRESSION_STORAGE_KEY = 'bst-progression';
 const PROGRESSION_STATE_VERSION = 1;
+const COIN_REWARDS = Object.freeze({
+  clearRegion: 4,
+  multiClearBonus: 3,
+  comboStep: 2,
+  roundCompletion: 2,
+  endRunBase: 10,
+  endRunPer50Score: 1,
+  personalBestBonus: 15,
+});
 
 function clampWholeNumber(value, fallback) {
   return Number.isInteger(value) && value >= 0 ? value : fallback;
@@ -296,6 +306,71 @@ function updateProgressionState(updater) {
 function resetProgressionState() {
   progressionState = createDefaultProgressionState();
   saveProgressionState();
+}
+
+function getCoinBalance() {
+  return progressionState?.coins?.balance || 0;
+}
+
+function updateCoinUI() {
+  const coinEl = document.getElementById('coin-balance');
+  if (!coinEl) return;
+  coinEl.textContent = getCoinBalance();
+}
+
+function awardCoins(amount, reason, options = {}) {
+  const wholeAmount = Math.max(0, Math.floor(amount));
+  if (!wholeAmount) return 0;
+
+  updateProgressionState(state => {
+    state.coins.balance += wholeAmount;
+    state.coins.lifetimeEarned += wholeAmount;
+    return state;
+  });
+
+  updateCoinUI();
+  if (!options.silent) showCoinToast(wholeAmount, reason);
+  return wholeAmount;
+}
+
+function calculateClearCoinReward(totalRegions, comboValue) {
+  if (!totalRegions) return 0;
+  return (totalRegions * COIN_REWARDS.clearRegion)
+    + (Math.max(0, totalRegions - 1) * COIN_REWARDS.multiClearBonus)
+    + (Math.max(0, comboValue - 1) * COIN_REWARDS.comboStep);
+}
+
+function clearRewardLabel(totalRegions, comboValue) {
+  if (totalRegions >= 2 && comboValue >= 2) return `${totalRegions}-clear combo`;
+  if (totalRegions >= 2) return `${totalRegions}-clear move`;
+  if (comboValue >= 2) return 'Combo bonus';
+  return 'Clear reward';
+}
+
+function calculateEndRunCoinReward(finalScore) {
+  return COIN_REWARDS.endRunBase + Math.floor(finalScore / 50) * COIN_REWARDS.endRunPer50Score;
+}
+
+function showCoinToast(amount, reason) {
+  const anchor = document.querySelector('.coins-stat') || document.getElementById('score-wrap');
+  if (!anchor) return;
+
+  const toast = document.createElement('div');
+  toast.className = 'coin-toast';
+  toast.innerHTML = `<strong>🪙 +${amount}</strong><span>${reason}</span>`;
+
+  const rect = anchor.getBoundingClientRect();
+  const maxLeft = Math.max(12, window.innerWidth - 232);
+  coinToastOffset = (coinToastOffset + 1) % 3;
+  toast.style.left = `${Math.min(maxLeft, Math.max(12, rect.left - 20 + coinToastOffset * 10))}px`;
+  toast.style.top = `${Math.max(12, rect.bottom + 8 + coinToastOffset * 6)}px`;
+
+  document.body.appendChild(toast);
+  toast.addEventListener('animationend', () => toast.remove(), { once: true });
+}
+
+function awardMissionCoins(amount, missionName = 'Mission complete') {
+  return awardCoins(amount, missionName);
 }
 
 // ── Piece helpers ──────────────────────────────────────────
@@ -940,6 +1015,9 @@ function doClears() {
   pts += combo * 5;
   score += pts;
 
+  const clearCoins = calculateClearCoinReward(total, combo);
+  awardCoins(clearCoins, clearRewardLabel(total, combo));
+
   for (const key of cleared) {
     const [r, c] = key.split(',').map(Number);
     board[r][c] = 0;
@@ -1030,10 +1108,14 @@ function isGameOver() {
 function triggerGameOver() {
   gameOver = true;
 
-  if (score > bestScore) {
+  const isNewBest = score > bestScore;
+  if (isNewBest) {
     bestScore = score;
     localStorage.setItem('bst-best', bestScore);
   }
+
+  awardCoins(calculateEndRunCoinReward(score), 'Run complete');
+  if (isNewBest) awardCoins(COIN_REWARDS.personalBestBonus, 'New best');
 
   const todayKey = new Date().toISOString().slice(0, 10);
   const td = JSON.parse(localStorage.getItem('bst-today') || '{"d":"","s":0}');
@@ -1082,6 +1164,8 @@ function showChooseCarefullyMsg() {
 
 // ── New round / restart ────────────────────────────────────
 function newRound() {
+  awardCoins(COIN_REWARDS.roundCompletion, 'Rack complete');
+
   used    = Array(rackSize).fill(false);
   pieces  = smartPieces();
   if (colorSetting === 'random') applyColor('random');
@@ -1099,6 +1183,7 @@ function startNewGame() {
   score    = 0;
   combo    = 0;
   gameOver = false;
+  coinToastOffset = 0;
   used     = Array(rackSize).fill(false);
   pieces   = smartPieces();
 
@@ -1122,6 +1207,7 @@ function updateScoreUI() {
   el.textContent = score;
   document.getElementById('today-val').textContent  = Math.max(todayScore, score);
   document.getElementById('best-val').textContent   = Math.max(bestScore, score);
+  updateCoinUI();
 
   // Bump animation when score changes
   if (String(score) !== prev) {
@@ -1519,6 +1605,7 @@ function init() {
   todayScore = (td.d === todayKey) ? td.s : 0;
 
   loadProgressionState();
+  updateCoinUI();
   loadSettings();
   applyDarkMode(darkMode);
   applyColor(colorSetting);

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
         <div id="score-sub">
           <span>Today&nbsp;<span id="today-val">0</span></span>
           <span>🏆&nbsp;<span id="best-val">0</span></span>
+          <span class="coins-stat" aria-live="polite" aria-label="Coins">🪙&nbsp;<span id="coin-balance">0</span></span>
         </div>
       </div>
       <button class="icon-btn" id="btn-settings" aria-label="Settings">

--- a/styles.css
+++ b/styles.css
@@ -108,10 +108,27 @@ a.icon-btn { text-decoration: none; }
 #score-sub {
   display: flex;
   justify-content: center;
-  gap: 14px;
+  gap: 10px 14px;
   font-size: 12px;
   color: var(--text-2);
   margin-top: 2px;
+  flex-wrap: wrap;
+}
+
+.coins-stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg-card));
+  color: color-mix(in srgb, var(--accent-dk) 70%, var(--text));
+  border: 1px solid color-mix(in srgb, var(--accent) 22%, var(--border));
+  font-weight: 700;
+}
+
+[data-theme="dark"] .coins-stat {
+  color: color-mix(in srgb, var(--accent-hi) 72%, var(--text));
 }
 
 /* ===== Main ===== */
@@ -271,6 +288,39 @@ a.icon-btn { text-decoration: none; }
   z-index: 3000;
   animation: pointsFloat 0.75s ease-out forwards;
   white-space: nowrap;
+}
+
+/* ===== Coin reward toast ===== */
+@keyframes coinToastIn {
+  0%   { transform: translateY(8px) scale(0.92); opacity: 0; }
+  18%  { transform: translateY(0) scale(1); opacity: 1; }
+  82%  { transform: translateY(-18px) scale(1); opacity: 1; }
+  100% { transform: translateY(-30px) scale(0.96); opacity: 0; }
+}
+.coin-toast {
+  position: fixed;
+  min-width: 140px;
+  max-width: min(220px, calc(100vw - 24px));
+  padding: 9px 12px;
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--accent) 20%, var(--bg-card));
+  border: 1px solid color-mix(in srgb, var(--accent) 26%, var(--border));
+  box-shadow: 0 10px 28px rgba(0,0,0,0.16);
+  color: var(--text);
+  pointer-events: none;
+  z-index: 3200;
+  animation: coinToastIn 1.45s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+.coin-toast strong {
+  display: block;
+  font-size: 16px;
+  line-height: 1.05;
+}
+.coin-toast span {
+  display: block;
+  margin-top: 3px;
+  font-size: 11px;
+  color: var(--text-2);
 }
 
 /* ===== Overlay transitions ===== */


### PR DESCRIPTION
### Motivation

- Provide a persistent soft currency so players earn and keep coins across sessions as part of progression and retention work. 
- Surface coin feedback during play so rewards for clears, combos and run completion are understandable and visible. 

### Description

- Introduced a deterministic coin economy in `app.js` with `COIN_REWARDS` tuning constants and helpers: `awardCoins`, `calculateClearCoinReward`, `calculateEndRunCoinReward`, `clearRewardLabel` and `updateCoinUI`.
- Wired coin payouts into gameplay events: region clears (`doClears`), rack completion (`newRound`), run completion and new personal best (`triggerGameOver`), and reset initial state in `startNewGame`/`init` via `loadProgressionState`/`updateCoinUI` using the existing `progressionState` persisted to `localStorage` under `bst-progression`.
- Added a compact live coin display to the header in `index.html` and styled it plus a transient reward toast in `styles.css` so coin gains are visible but unobtrusive during play.
- Updated the agent issue queue in `AGENTS.md` to mark issue #33 completed and advance the TODO list.

### Testing

- Ran `node --check app.js` to verify syntax; result: success.
- Ran `sh scripts/validate-static-site.sh` and `sh scripts/test-validation-portability.sh` to validate static site expectations and portability; result: success.
- Started a local server and fetched `index.html` with `python3 -m http.server` and `curl -I` to smoke-test the served site; result: success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf1041369483338f3ead0f0e772ebd)