### PR TITLE
Add post-run rewards summary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,13 +24,13 @@ When a user says "implement the next issue", inspect the lists below, pick the f
 
 ### TODO
 
-1. [#34 Add a post-run rewards summary](https://github.com/Bigalan09/Burohame/issues/34)
-2. [#35 Add daily missions with coin rewards](https://github.com/Bigalan09/Burohame/issues/35)
-3. [#36 Add a cosmetics collection and unlock flow](https://github.com/Bigalan09/Burohame/issues/36)
-4. [#37 Add delight feedback for milestone moments](https://github.com/Bigalan09/Burohame/issues/37)
-5. [#38 Add a daily challenge and streak system](https://github.com/Bigalan09/Burohame/issues/38)
+1. [#35 Add daily missions with coin rewards](https://github.com/Bigalan09/Burohame/issues/35)
+2. [#36 Add a cosmetics collection and unlock flow](https://github.com/Bigalan09/Burohame/issues/36)
+3. [#37 Add delight feedback for milestone moments](https://github.com/Bigalan09/Burohame/issues/37)
+4. [#38 Add a daily challenge and streak system](https://github.com/Bigalan09/Burohame/issues/38)
 
 ### Completed
 
+- [#34 Add a post-run rewards summary](https://github.com/Bigalan09/Burohame/issues/34)
 - [#33 Add coins as a persistent soft currency](https://github.com/Bigalan09/Burohame/issues/33)
 - [#32 Add persistent progression state for retention features](https://github.com/Bigalan09/Burohame/issues/32)

--- a/app.js
+++ b/app.js
@@ -179,6 +179,7 @@ let colorSetting = 'orange';   // 'orange','blue','green','purple','red','teal',
 let rackSize     = 3;          // number of pieces shown in the rack (1–3)
 let progressionState = null;
 let coinToastOffset = 0;
+let runSummary = null;
 
 const COLOR_NAMES = ['orange','blue','green','purple','red','teal','pink'];
 const PROGRESSION_STORAGE_KEY = 'bst-progression';
@@ -192,6 +193,38 @@ const COIN_REWARDS = Object.freeze({
   endRunPer50Score: 1,
   personalBestBonus: 15,
 });
+const RUN_OBJECTIVES = Object.freeze([
+  {
+    id: 'first-clear',
+    label: 'First clear',
+    description: 'Clear at least one region during the run.',
+    isComplete: summary => summary.stats.regionsCleared >= 1,
+  },
+  {
+    id: 'combo-builder',
+    label: 'Combo builder',
+    description: 'Reach a 3× combo or better.',
+    isComplete: summary => summary.stats.maxCombo >= 3,
+  },
+  {
+    id: 'rack-runner',
+    label: 'Rack runner',
+    description: 'Finish two full racks in one run.',
+    isComplete: summary => summary.stats.racksCompleted >= 2,
+  },
+  {
+    id: 'centurion',
+    label: 'Centurion',
+    description: 'Score 100 points or more.',
+    isComplete: summary => summary.finalScore >= 100,
+  },
+  {
+    id: 'personal-best',
+    label: 'Personal best',
+    description: 'Beat your previous best score.',
+    isComplete: summary => summary.stats.personalBest,
+  },
+]);
 
 function clampWholeNumber(value, fallback) {
   return Number.isInteger(value) && value >= 0 ? value : fallback;
@@ -280,6 +313,75 @@ function sanitiseProgressionState(rawState) {
   };
 }
 
+function createDefaultRunSummary() {
+  return {
+    finalScore: 0,
+    coinsEarned: 0,
+    completedObjectiveIds: [],
+    stats: {
+      regionsCleared: 0,
+      maxCombo: 0,
+      racksCompleted: 0,
+      personalBest: false,
+    },
+  };
+}
+
+function ensureRunSummary() {
+  if (!runSummary) runSummary = createDefaultRunSummary();
+  return runSummary;
+}
+
+function recordRunObjective(objectiveId) {
+  const summary = ensureRunSummary();
+  if (!summary.completedObjectiveIds.includes(objectiveId)) {
+    summary.completedObjectiveIds.push(objectiveId);
+  }
+}
+
+function evaluateRunObjectives() {
+  const summary = ensureRunSummary();
+  summary.finalScore = score;
+
+  for (const objective of RUN_OBJECTIVES) {
+    if (objective.isComplete(summary)) recordRunObjective(objective.id);
+  }
+}
+
+function getCompletedRunObjectives() {
+  const summary = ensureRunSummary();
+  return RUN_OBJECTIVES.filter(objective => summary.completedObjectiveIds.includes(objective.id));
+}
+
+function renderGameOverSummary() {
+  const summary = ensureRunSummary();
+  const objectives = getCompletedRunObjectives();
+  const objectivesList = document.getElementById('go-objectives-list');
+  const objectiveCount = document.getElementById('go-objective-count');
+
+  document.getElementById('go-score').textContent = String(summary.finalScore);
+  document.getElementById('go-best').textContent = String(bestScore);
+  document.getElementById('go-coins-earned').textContent = `+${summary.coinsEarned}`;
+  document.getElementById('go-coin-total').textContent = String(getCoinBalance());
+  objectiveCount.textContent = objectives.length === 1 ? '1 cleared' : `${objectives.length} cleared`;
+
+  objectivesList.innerHTML = '';
+  if (!objectives.length) {
+    const emptyItem = document.createElement('li');
+    emptyItem.className = 'run-objective run-objective--empty';
+    emptyItem.textContent = 'No objectives completed this run. Your next run can still earn coins and milestones.';
+    objectivesList.appendChild(emptyItem);
+    return;
+  }
+
+  for (const objective of objectives) {
+    const item = document.createElement('li');
+    item.className = 'run-objective';
+    item.innerHTML = `<strong>${objective.label}</strong><span>${objective.description}</span>`;
+    objectivesList.appendChild(item);
+  }
+}
+
 function saveProgressionState() {
   localStorage.setItem(PROGRESSION_STORAGE_KEY, JSON.stringify(progressionState));
 }
@@ -327,6 +429,10 @@ function awardCoins(amount, reason, options = {}) {
     state.coins.lifetimeEarned += wholeAmount;
     return state;
   });
+
+  if (!options.excludeFromRunSummary) {
+    ensureRunSummary().coinsEarned += wholeAmount;
+  }
 
   updateCoinUI();
   if (!options.silent) showCoinToast(wholeAmount, reason);
@@ -947,6 +1053,7 @@ function doPlace(slotIdx, row, col) {
 
   // Check clears
   const cleared = doClears();
+  evaluateRunObjectives();
 
   if (cleared.size) {
     showPointsPopup(cleared.size);
@@ -1014,6 +1121,9 @@ function doClears() {
   combo += total;   // combo grows by every region cleared in this move
   pts += combo * 5;
   score += pts;
+  const summary = ensureRunSummary();
+  summary.stats.regionsCleared += total;
+  summary.stats.maxCombo = Math.max(summary.stats.maxCombo, combo);
 
   const clearCoins = calculateClearCoinReward(total, combo);
   awardCoins(clearCoins, clearRewardLabel(total, combo));
@@ -1106,6 +1216,7 @@ function isGameOver() {
 }
 
 function triggerGameOver() {
+  if (gameOver) return;
   gameOver = true;
 
   const isNewBest = score > bestScore;
@@ -1116,17 +1227,18 @@ function triggerGameOver() {
 
   awardCoins(calculateEndRunCoinReward(score), 'Run complete');
   if (isNewBest) awardCoins(COIN_REWARDS.personalBestBonus, 'New best');
+  ensureRunSummary().stats.personalBest = isNewBest;
 
   const todayKey = new Date().toISOString().slice(0, 10);
   const td = JSON.parse(localStorage.getItem('bst-today') || '{"d":"","s":0}');
   todayScore = (td.d === todayKey) ? Math.max(td.s, score) : score;
   localStorage.setItem('bst-today', JSON.stringify({ d: todayKey, s: todayScore }));
   updateScoreUI();
+  evaluateRunObjectives();
 
   // Fade in "No more space!", hold, then fade out before showing the game-over card.
   showNoMoreSpaceMsg(() => {
-    document.getElementById('go-score').textContent = `Score: ${score}`;
-    document.getElementById('go-best').textContent  = `Best: ${bestScore}`;
+    renderGameOverSummary();
     showOverlay('ov-gameover');
   });
 }
@@ -1164,7 +1276,9 @@ function showChooseCarefullyMsg() {
 
 // ── New round / restart ────────────────────────────────────
 function newRound() {
+  ensureRunSummary().stats.racksCompleted += 1;
   awardCoins(COIN_REWARDS.roundCompletion, 'Rack complete');
+  evaluateRunObjectives();
 
   used    = Array(rackSize).fill(false);
   pieces  = smartPieces();
@@ -1184,6 +1298,7 @@ function startNewGame() {
   combo    = 0;
   gameOver = false;
   coinToastOffset = 0;
+  runSummary = createDefaultRunSummary();
   used     = Array(rackSize).fill(false);
   pieces   = smartPieces();
 

--- a/index.html
+++ b/index.html
@@ -121,11 +121,35 @@
 
     <!-- Game-over overlay -->
     <div id="ov-gameover" class="overlay" hidden>
-      <div class="ov-card">
+      <div class="ov-card ov-card--summary">
         <h2>Game Over</h2>
-        <p id="go-score"></p>
-        <p id="go-best"></p>
-        <button class="pill-btn wide" id="btn-new">New Game</button>
+        <p class="summary-intro">Your run rewards are ready.</p>
+        <div class="run-summary" aria-label="Run rewards summary">
+          <div class="summary-stat summary-stat--score">
+            <span class="summary-label">Score</span>
+            <strong id="go-score">0</strong>
+          </div>
+          <div class="summary-stat">
+            <span class="summary-label">Best</span>
+            <strong id="go-best">0</strong>
+          </div>
+          <div class="summary-stat summary-stat--coins">
+            <span class="summary-label">Coins this run</span>
+            <strong id="go-coins-earned">0</strong>
+          </div>
+          <div class="summary-stat">
+            <span class="summary-label">Total coins</span>
+            <strong id="go-coin-total">0</strong>
+          </div>
+        </div>
+        <section class="run-objectives" aria-labelledby="go-objectives-title">
+          <div class="run-objectives__header">
+            <h3 id="go-objectives-title">Completed objectives</h3>
+            <span id="go-objective-count" class="run-objectives__count">0 cleared</span>
+          </div>
+          <ul id="go-objectives-list" class="run-objectives__list"></ul>
+        </section>
+        <button class="pill-btn wide summary-primary-btn" id="btn-new">Start next run</button>
       </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -527,6 +527,137 @@ a.icon-btn { text-decoration: none; }
   margin-bottom: 4px;
 }
 
+.ov-card--summary {
+  max-width: 360px;
+  padding: 24px 20px 20px;
+  text-align: left;
+}
+
+.ov-card--summary h2 {
+  margin-bottom: 6px;
+}
+
+.summary-intro {
+  margin-bottom: 16px;
+}
+
+.run-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.summary-stat {
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--accent) 16%, var(--border));
+}
+
+.summary-stat--score,
+.summary-stat--coins {
+  background: color-mix(in srgb, var(--accent) 14%, var(--bg));
+}
+
+.summary-label {
+  display: block;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--text-2);
+}
+
+.summary-stat strong {
+  display: block;
+  margin-top: 6px;
+  font-size: 24px;
+  line-height: 1;
+  color: var(--text);
+}
+
+.run-objectives {
+  margin-top: 4px;
+}
+
+.run-objectives__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.run-objectives__header h3 {
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.run-objectives__count {
+  font-size: 12px;
+  color: var(--text-2);
+}
+
+.run-objectives__list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.run-objective {
+  position: relative;
+  padding: 11px 12px;
+  padding-left: 44px;
+  border-radius: 14px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+}
+
+.run-objective strong,
+.run-objective span {
+  display: block;
+}
+
+.run-objective strong {
+  font-size: 14px;
+  color: var(--text);
+}
+
+.run-objective span {
+  margin-top: 3px;
+  font-size: 12px;
+  color: var(--text-2);
+}
+
+.run-objective::before {
+  content: '✓';
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 22%, var(--bg-card));
+  color: color-mix(in srgb, var(--accent-dk) 74%, var(--text));
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.run-objective--empty::before {
+  content: '•';
+}
+
+.summary-primary-btn {
+  margin-top: 16px;
+  font-size: 16px;
+  padding-block: 14px;
+}
+
 /* ===== Toggle switch ===== */
 .tog-row {
   display: flex;
@@ -676,6 +807,23 @@ input:checked + .tog-track .tog-thumb { transform: translateX(20px); }
   #hdr { padding: 4px 12px; }
   .slot { min-height: 56px; }
   #board-wrap { width: min(100%, calc(100dvh - 220px)); }
+  .ov-card--summary {
+    max-width: 340px;
+    padding: 20px 18px 18px;
+  }
+  .run-summary {
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+  .summary-stat {
+    padding: 10px 12px;
+  }
+  .summary-stat strong {
+    font-size: 21px;
+  }
+  .run-objective {
+    padding: 9px 11px 9px 40px;
+  }
 }
 
 @media (min-width: 430px) {


### PR DESCRIPTION
### Motivation
- Ship the post-run rewards summary from issue #34 so players see score, coins earned this run and completed objectives at the end of a run. 
- Surface per-run rewards and objective progress to support retention features and make the end-of-run moment more actionable.

### Description
- Expand the game-over overlay into a compact post-run summary UI showing Score, Best, Coins this run, Total coins and a list of completed objectives, with responsive styling in `styles.css` and markup in `index.html`.
- Add run-tracking logic to `app.js`: a `runSummary` structure, `RUN_OBJECTIVES` definitions, and helper functions `createDefaultRunSummary`, `ensureRunSummary`, `recordRunObjective`, `evaluateRunObjectives`, `getCompletedRunObjectives` and `renderGameOverSummary` that evaluate and render objectives as the run progresses.
- Integrate the summary with game flow by updating `awardCoins` to accumulate per-run earnings, calling `evaluateRunObjectives` from `doPlace`, `doClears`, `newRound` and `triggerGameOver`, and rendering the summary when a run ends.
- Update `AGENTS.md` to mark the post-run rewards summary task as completed in the local issue queue.

### Testing
- Ran `node --check app.js` to validate JavaScript syntax, which succeeded. 
- Ran `sh scripts/validate-static-site.sh` static-site checks, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf16ca53b48333b46d6048101972b7)