### PR TITLE
Add daily missions with coin rewards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,13 +24,13 @@ When a user says "implement the next issue", inspect the lists below, pick the f
 
 ### TODO
 
-1. [#35 Add daily missions with coin rewards](https://github.com/Bigalan09/Burohame/issues/35)
-2. [#36 Add a cosmetics collection and unlock flow](https://github.com/Bigalan09/Burohame/issues/36)
-3. [#37 Add delight feedback for milestone moments](https://github.com/Bigalan09/Burohame/issues/37)
-4. [#38 Add a daily challenge and streak system](https://github.com/Bigalan09/Burohame/issues/38)
+1. [#36 Add a cosmetics collection and unlock flow](https://github.com/Bigalan09/Burohame/issues/36)
+2. [#37 Add delight feedback for milestone moments](https://github.com/Bigalan09/Burohame/issues/37)
+3. [#38 Add a daily challenge and streak system](https://github.com/Bigalan09/Burohame/issues/38)
 
 ### Completed
 
 - [#34 Add a post-run rewards summary](https://github.com/Bigalan09/Burohame/issues/34)
+- [#35 Add daily missions with coin rewards](https://github.com/Bigalan09/Burohame/issues/35)
 - [#33 Add coins as a persistent soft currency](https://github.com/Bigalan09/Burohame/issues/33)
 - [#32 Add persistent progression state for retention features](https://github.com/Bigalan09/Burohame/issues/32)

--- a/app.js
+++ b/app.js
@@ -193,6 +193,56 @@ const COIN_REWARDS = Object.freeze({
   endRunPer50Score: 1,
   personalBestBonus: 15,
 });
+const DAILY_MISSION_TEMPLATES = Object.freeze([
+  {
+    templateId: 'score-120',
+    kind: 'score',
+    goal: 120,
+    reward: 18,
+    title: 'Point collector',
+    description: 'Score 120 points across today’s runs.',
+  },
+  {
+    templateId: 'blocks-30',
+    kind: 'blocks',
+    goal: 30,
+    reward: 14,
+    title: 'Builder’s rhythm',
+    description: 'Place 30 blocks today.',
+  },
+  {
+    templateId: 'regions-8',
+    kind: 'regions',
+    goal: 8,
+    reward: 16,
+    title: 'Board cleaner',
+    description: 'Clear 8 regions today.',
+  },
+  {
+    templateId: 'racks-4',
+    kind: 'racks',
+    goal: 4,
+    reward: 12,
+    title: 'Rack runner',
+    description: 'Finish 4 full racks today.',
+  },
+  {
+    templateId: 'combo-4',
+    kind: 'combo',
+    goal: 4,
+    reward: 20,
+    title: 'Heat check',
+    description: 'Reach a 4× combo in a run today.',
+  },
+  {
+    templateId: 'runs-3',
+    kind: 'runs',
+    goal: 3,
+    reward: 10,
+    title: 'Keep going',
+    description: 'Complete 3 runs today.',
+  },
+]);
 const RUN_OBJECTIVES = Object.freeze([
   {
     id: 'first-clear',
@@ -235,6 +285,66 @@ function uniqueStringList(value, fallback) {
   return [...new Set(value.filter(item => typeof item === 'string' && item.trim() !== ''))];
 }
 
+function getLocalDateKey(date = new Date()) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function hashString(value) {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function createDailyMissionEntry(template, dateKey) {
+  return {
+    id: `${dateKey}-${template.templateId}`,
+    templateId: template.templateId,
+    kind: template.kind,
+    title: template.title,
+    description: template.description,
+    goal: template.goal,
+    progress: 0,
+    reward: template.reward,
+  };
+}
+
+function createDailyMissionSet(dateKey) {
+  const seeded = DAILY_MISSION_TEMPLATES
+    .map(template => ({
+      template,
+      score: hashString(`${dateKey}:${template.templateId}`),
+    }))
+    .sort((a, b) => a.score - b.score)
+    .slice(0, 3);
+
+  return seeded.map(({ template }) => createDailyMissionEntry(template, dateKey));
+}
+
+function sanitiseMissionEntry(value) {
+  const src = value && typeof value === 'object' ? value : {};
+  const id = typeof src.id === 'string' ? src.id : '';
+  const title = typeof src.title === 'string' && src.title.trim() !== ''
+    ? src.title
+    : 'Daily mission';
+
+  return {
+    id,
+    templateId: typeof src.templateId === 'string' ? src.templateId : '',
+    kind: typeof src.kind === 'string' ? src.kind : 'score',
+    title,
+    description: typeof src.description === 'string' ? src.description : '',
+    goal: Math.max(1, clampWholeNumber(src.goal, 1)),
+    progress: clampWholeNumber(src.progress, 0),
+    reward: clampWholeNumber(src.reward, 0),
+  };
+}
+
 function createDefaultProgressionState() {
   return {
     version: PROGRESSION_STATE_VERSION,
@@ -267,9 +377,14 @@ function createDefaultProgressionState() {
 
 function sanitiseMissionState(value) {
   const src = value && typeof value === 'object' ? value : {};
+  const missions = Array.isArray(src.missions)
+    ? src.missions
+      .map(sanitiseMissionEntry)
+      .filter(mission => mission.id)
+    : [];
   return {
     date: typeof src.date === 'string' ? src.date : '',
-    missions: Array.isArray(src.missions) ? src.missions : [],
+    missions,
     completedIds: uniqueStringList(src.completedIds, []),
     claimedIds: uniqueStringList(src.claimedIds, []),
     refreshCount: clampWholeNumber(src.refreshCount, 0),
@@ -477,6 +592,138 @@ function showCoinToast(amount, reason) {
 
 function awardMissionCoins(amount, missionName = 'Mission complete') {
   return awardCoins(amount, missionName);
+}
+
+function ensureDailyMissionsForToday() {
+  const todayKey = getLocalDateKey();
+  const currentDate = progressionState?.dailyMissions?.date || '';
+  if (currentDate === todayKey && progressionState?.dailyMissions?.missions?.length) {
+    return progressionState.dailyMissions;
+  }
+
+  const nextState = updateProgressionState(state => {
+    const refreshCount = clampWholeNumber(state.dailyMissions?.refreshCount, 0);
+    state.dailyMissions = {
+      date: todayKey,
+      missions: createDailyMissionSet(todayKey),
+      completedIds: [],
+      claimedIds: [],
+      refreshCount: currentDate ? refreshCount + 1 : refreshCount,
+    };
+    return state;
+  });
+
+  return nextState.dailyMissions;
+}
+
+function getDailyMissionProgressText(mission) {
+  const progress = Math.min(mission.progress, mission.goal);
+  if (mission.kind === 'combo') return `Best combo ${progress}/${mission.goal}`;
+  if (mission.kind === 'runs') return `${progress}/${mission.goal} runs completed`;
+  if (mission.kind === 'racks') return `${progress}/${mission.goal} racks completed`;
+  if (mission.kind === 'regions') return `${progress}/${mission.goal} regions cleared`;
+  if (mission.kind === 'blocks') return `${progress}/${mission.goal} blocks placed`;
+  return `${progress}/${mission.goal} points scored`;
+}
+
+function getDailyMissionCounts() {
+  const missionState = progressionState?.dailyMissions;
+  const total = missionState?.missions?.length || 0;
+  const completed = missionState?.claimedIds?.length || 0;
+  return { completed, total };
+}
+
+function renderDailyMissions() {
+  const missionState = ensureDailyMissionsForToday();
+  const list = document.getElementById('missions-list');
+  const count = document.getElementById('missions-count');
+  const subtitle = document.getElementById('missions-subtitle');
+  const badge = document.getElementById('mission-badge');
+  if (!list || !count || !subtitle || !badge) return;
+
+  const { completed, total } = getDailyMissionCounts();
+  count.textContent = `${completed}/${total} completed`;
+  subtitle.textContent = `Fresh goals for ${missionState.date}. Rewards are paid automatically when you finish them.`;
+  badge.textContent = total ? `${completed}/${total}` : '0/0';
+  badge.hidden = !total;
+
+  list.innerHTML = '';
+  if (!missionState.missions.length) {
+    const empty = document.createElement('p');
+    empty.className = 'missions-empty';
+    empty.textContent = 'No daily missions are available right now.';
+    list.appendChild(empty);
+    return;
+  }
+
+  for (const mission of missionState.missions) {
+    const progress = Math.min(mission.progress, mission.goal);
+    const isClaimed = missionState.claimedIds.includes(mission.id);
+    const isCompleted = missionState.completedIds.includes(mission.id);
+    const item = document.createElement('article');
+    item.className = 'mission-item';
+    if (isClaimed) item.classList.add('mission-item--claimed');
+    if (isCompleted && !isClaimed) item.classList.add('mission-item--complete');
+
+    const percentage = Math.max(0, Math.min(100, Math.round((progress / mission.goal) * 100)));
+    item.innerHTML = `
+      <div class="mission-item__top">
+        <div>
+          <h3>${mission.title}</h3>
+          <p>${mission.description}</p>
+        </div>
+        <div class="mission-item__reward">🪙 ${mission.reward}</div>
+      </div>
+      <div class="mission-progress" aria-hidden="true">
+        <span style="width:${percentage}%"></span>
+      </div>
+      <div class="mission-item__footer">
+        <span>${getDailyMissionProgressText(mission)}</span>
+        <strong>${isClaimed ? 'Claimed' : isCompleted ? 'Complete' : 'In progress'}</strong>
+      </div>
+    `;
+    list.appendChild(item);
+  }
+}
+
+function updateDailyMissionProgress(kind, value, mode = 'increment') {
+  const amount = Math.max(0, Math.floor(value));
+  if (!amount) return;
+
+  ensureDailyMissionsForToday();
+  const rewardsToGrant = [];
+
+  updateProgressionState(state => {
+    const missionState = state.dailyMissions;
+    if (!missionState || !Array.isArray(missionState.missions)) return state;
+
+    for (const mission of missionState.missions) {
+      if (mission.kind !== kind) continue;
+
+      if (mode === 'max') {
+        mission.progress = Math.max(mission.progress, amount);
+      } else {
+        mission.progress += amount;
+      }
+
+      if (mission.progress >= mission.goal && !missionState.completedIds.includes(mission.id)) {
+        missionState.completedIds.push(mission.id);
+      }
+
+      if (mission.progress >= mission.goal && !missionState.claimedIds.includes(mission.id)) {
+        missionState.claimedIds.push(mission.id);
+        rewardsToGrant.push({
+          reward: mission.reward,
+          reason: `${mission.title} complete`,
+        });
+      }
+    }
+
+    return state;
+  });
+
+  renderDailyMissions();
+  rewardsToGrant.forEach(({ reward, reason }) => awardMissionCoins(reward, reason));
 }
 
 // ── Piece helpers ──────────────────────────────────────────
@@ -1028,6 +1275,8 @@ function doPlace(slotIdx, row, col) {
   // Place blocks on board
   for (const [dr, dc] of cells) board[row + dr][col + dc] = 1;
   score += cells.length;
+  updateDailyMissionProgress('blocks', cells.length);
+  updateDailyMissionProgress('score', cells.length);
   updateScoreUI();
 
   used[slotIdx] = true;
@@ -1124,6 +1373,9 @@ function doClears() {
   const summary = ensureRunSummary();
   summary.stats.regionsCleared += total;
   summary.stats.maxCombo = Math.max(summary.stats.maxCombo, combo);
+  updateDailyMissionProgress('regions', total);
+  updateDailyMissionProgress('score', pts);
+  updateDailyMissionProgress('combo', combo, 'max');
 
   const clearCoins = calculateClearCoinReward(total, combo);
   awardCoins(clearCoins, clearRewardLabel(total, combo));
@@ -1235,6 +1487,7 @@ function triggerGameOver() {
   localStorage.setItem('bst-today', JSON.stringify({ d: todayKey, s: todayScore }));
   updateScoreUI();
   evaluateRunObjectives();
+  updateDailyMissionProgress('runs', 1);
 
   // Fade in "No more space!", hold, then fade out before showing the game-over card.
   showNoMoreSpaceMsg(() => {
@@ -1279,6 +1532,7 @@ function newRound() {
   ensureRunSummary().stats.racksCompleted += 1;
   awardCoins(COIN_REWARDS.roundCompletion, 'Rack complete');
   evaluateRunObjectives();
+  updateDailyMissionProgress('racks', 1);
 
   used    = Array(rackSize).fill(false);
   pieces  = smartPieces();
@@ -1644,6 +1898,15 @@ document.getElementById('btn-settings').addEventListener('click', () => {
   showOverlay('ov-settings');
 });
 
+document.getElementById('btn-missions').addEventListener('click', () => {
+  renderDailyMissions();
+  showOverlay('ov-missions');
+});
+
+document.getElementById('btn-missions-close').addEventListener('click', () => {
+  hideOverlay('ov-missions');
+});
+
 document.getElementById('btn-done').addEventListener('click', () => {
   const prev = trainingMode;
   const prevRackSize = rackSize;
@@ -1707,6 +1970,11 @@ document.getElementById('btn-restart').addEventListener('click', startNewGame);
 
 document.getElementById('btn-new').addEventListener('click', startNewGame);
 
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState !== 'visible') return;
+  renderDailyMissions();
+});
+
 // Prevent body scroll while dragging on iOS
 document.addEventListener('touchstart', e => {
   if (e.target.closest('.slot')) e.preventDefault();
@@ -1720,6 +1988,7 @@ function init() {
   todayScore = (td.d === todayKey) ? td.s : 0;
 
   loadProgressionState();
+  ensureDailyMissionsForToday();
   updateCoinUI();
   loadSettings();
   applyDarkMode(darkMode);
@@ -1740,6 +2009,7 @@ function init() {
 
   initBoardDOM();
   initRackDOM();
+  renderDailyMissions();
   startNewGame();
 }
 

--- a/index.html
+++ b/index.html
@@ -31,12 +31,20 @@
           <span class="coins-stat" aria-live="polite" aria-label="Coins">🪙&nbsp;<span id="coin-balance">0</span></span>
         </div>
       </div>
-      <button class="icon-btn" id="btn-settings" aria-label="Settings">
-        <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
-          <circle cx="10" cy="10" r="2.5" stroke="currentColor" stroke-width="2"/>
-          <path d="M10 1.5v2M10 16.5v2M1.5 10h2M16.5 10h2M4.1 4.1l1.4 1.4M14.5 14.5l1.4 1.4M4.1 15.9l1.4-1.4M14.5 5.5l1.4-1.4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
-        </svg>
-      </button>
+      <div class="header-actions">
+        <button class="icon-btn mission-btn" id="btn-missions" aria-label="Daily missions">
+          <span class="mission-btn__badge" id="mission-badge" hidden>0/0</span>
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+            <path d="M10 2.25l2.4 4.86 5.36.78-3.88 3.78.92 5.33L10 14.55 5.2 17l.92-5.33L2.24 7.89l5.36-.78L10 2.25z" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"/>
+          </svg>
+        </button>
+        <button class="icon-btn" id="btn-settings" aria-label="Settings">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+            <circle cx="10" cy="10" r="2.5" stroke="currentColor" stroke-width="2"/>
+            <path d="M10 1.5v2M10 16.5v2M1.5 10h2M16.5 10h2M4.1 4.1l1.4 1.4M14.5 14.5l1.4 1.4M4.1 15.9l1.4-1.4M14.5 5.5l1.4-1.4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+          </svg>
+        </button>
+      </div>
     </header>
 
     <!-- Main play area -->
@@ -116,6 +124,21 @@
         </div>
         <button class="pill-btn wide" id="btn-done">Done</button>
         <button class="pill-btn wide danger" id="btn-clear-data">🗑️ Clear All Data</button>
+      </div>
+    </div>
+
+    <!-- Daily missions overlay -->
+    <div id="ov-missions" class="overlay" hidden>
+      <div class="ov-card ov-card--missions">
+        <div class="missions-head">
+          <div>
+            <h2>Daily missions</h2>
+            <p id="missions-subtitle">Fresh goals are on the way.</p>
+          </div>
+          <span class="missions-count" id="missions-count">0/0 completed</span>
+        </div>
+        <div id="missions-list" class="missions-list" aria-live="polite"></div>
+        <button class="pill-btn wide" id="btn-missions-close">Back to game</button>
       </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -75,6 +75,12 @@ html, body {
   flex-shrink: 0;
 }
 
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .icon-btn {
   width: 36px;
   height: 36px;
@@ -91,6 +97,25 @@ html, body {
 }
 a.icon-btn { text-decoration: none; }
 .icon-btn:active { opacity: 0.6; }
+
+.mission-btn {
+  position: relative;
+}
+
+.mission-btn__badge {
+  position: absolute;
+  top: -4px;
+  right: -6px;
+  min-width: 30px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.1;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.18);
+}
 
 #score-wrap {
   flex: 1;
@@ -515,6 +540,11 @@ a.icon-btn { text-decoration: none; }
   box-shadow: 0 8px 32px rgba(0,0,0,0.25);
 }
 
+.ov-card--missions {
+  max-width: 380px;
+  text-align: left;
+}
+
 .ov-card h2 {
   font-size: 22px;
   font-weight: 700;
@@ -656,6 +686,121 @@ a.icon-btn { text-decoration: none; }
   margin-top: 16px;
   font-size: 16px;
   padding-block: 14px;
+}
+
+.missions-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.missions-head p {
+  margin-top: 6px;
+  margin-bottom: 0;
+  font-size: 13px;
+}
+
+.missions-count {
+  flex-shrink: 0;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--accent) 18%, var(--border));
+  color: color-mix(in srgb, var(--accent-dk) 72%, var(--text));
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.missions-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.missions-empty {
+  padding: 18px 16px;
+  border-radius: 16px;
+  background: var(--bg);
+  border: 1px dashed var(--border);
+  color: var(--text-2);
+  text-align: center;
+}
+
+.mission-item {
+  padding: 14px 14px 12px;
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--accent) 6%, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--accent) 14%, var(--border));
+}
+
+.mission-item--complete,
+.mission-item--claimed {
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg));
+}
+
+.mission-item__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mission-item__top h3 {
+  font-size: 16px;
+  line-height: 1.15;
+}
+
+.mission-item__top p {
+  margin-top: 4px;
+  margin-bottom: 0;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.mission-item__reward {
+  flex-shrink: 0;
+  padding: 5px 10px;
+  border-radius: 999px;
+  background: var(--bg-card);
+  border: 1px solid color-mix(in srgb, var(--accent) 16%, var(--border));
+  font-size: 13px;
+  font-weight: 800;
+  color: color-mix(in srgb, var(--accent-dk) 68%, var(--text));
+}
+
+.mission-progress {
+  width: 100%;
+  height: 10px;
+  margin-top: 12px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 8%, var(--border));
+  overflow: hidden;
+}
+
+.mission-progress span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent) 0%, var(--accent-hi) 100%);
+}
+
+.mission-item__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 10px;
+  font-size: 12px;
+  color: var(--text-2);
+}
+
+.mission-item__footer strong {
+  color: var(--text);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 /* ===== Toggle switch ===== */
@@ -823,6 +968,12 @@ input:checked + .tog-track .tog-thumb { transform: translateX(20px); }
   }
   .run-objective {
     padding: 9px 11px 9px 40px;
+  }
+  .mission-item {
+    padding: 12px;
+  }
+  .mission-item__top h3 {
+    font-size: 15px;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Provide short-term, daily goals to increase player engagement and reward play with persistent soft currency. 
- Persist missions per local day and ensure progress updates during normal gameplay without interrupting core mechanics. 
- Offer a lightweight UI so players can review today’s missions and earned rewards at any time.

### Description
- Added a mission system and templates in `app.js` (`DAILY_MISSION_TEMPLATES`) and implemented creation, sanitisation and seeding of a three-mission set per local day (`createDailyMissionSet`, `createDailyMissionEntry`, `sanitiseMissionEntry`, `sanitiseMissionState`, `ensureDailyMissionsForToday`).
- Tracked progress and automatic one-time coin awarding via `updateDailyMissionProgress` and wired progress hooks into gameplay events including block placement (`doPlace`), region clears (`doClears`), rack completion (`newRound`) and run completion (`triggerGameOver`).
- Added a header shortcut and a dedicated overlay to review daily missions (`index.html` additions and `ov-missions`), plus styles in `styles.css` to display progress bars, rewards and completion state. 
- Updated repository workflow bookkeeping by moving issue #35 from `TODO` to `Completed` in `AGENTS.md` to reflect the implemented task.

### Testing
- Ran syntax check with `node --check app.js` and it completed successfully. 
- Ran site validation with `sh scripts/validate-static-site.sh` and it passed. 
- Ran portability and workflow validation with `sh scripts/test-validation-portability.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf5a78b0e48333b3f17cc82ca69a3d)