### PR TITLE
Introduce persistent bottom navigation and simplify dashboard UI

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,17 @@
+## Design Context
+
+### Users
+People playing Burohame as a quick mobile puzzle game, usually in short sessions. They want to get into a run quickly, check progress at a glance, and make small setup changes without friction.
+
+### Brand Personality
+Calm, playful, focused. The interface should feel light, tidy, and quietly game-like rather than loud or overly technical.
+
+### Aesthetic Direction
+Calm arcade. Keep the dashboard distilled, mobile-first, and easy to scan. Use a small amount of warmth and character from the block visuals, but remove redundant copy, page numbering, and card-heavy navigation. Prefer a clear bottom navigation bar with simple iconography.
+
+### Design Principles
+- Start play quickly, with one obvious primary action.
+- Show only the progress details that help the next decision.
+- Remove repeated labels, explanations, and page numbering.
+- Keep navigation persistent, simple, and thumb-friendly.
+- Let spacing and hierarchy do the work instead of extra containers.

--- a/app.js
+++ b/app.js
@@ -1330,13 +1330,11 @@ function renderDashboard() {
     newGameBtn.textContent = hasSavedGame ? 'Start fresh run' : 'Start new run';
   }
   if (intro) {
-    intro.textContent = hasSavedGame
-      ? 'Continue where you left off, or start a fresh run from the dashboard.'
-      : 'Pick up a fresh run, visit the shop, or tune your setup before playing.';
+    intro.textContent = hasSavedGame ? 'Pick up where you left off.' : 'One tap to start playing.';
   }
   if (missionCopy) {
     missionCopy.textContent = missionCounts.total
-      ? `${missionCounts.completed}/${missionCounts.total} missions completed today.`
+      ? `${missionCounts.completed} of ${missionCounts.total} done today`
       : 'Fresh goals are on the way.';
   }
 
@@ -1360,6 +1358,14 @@ function populateSettingsPage() {
   updateCosmeticLabel();
 }
 
+function updateBottomNav() {
+  document.querySelectorAll('.bottom-nav__item').forEach(button => {
+    const isActive = button.dataset.navPage === currentPage;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-current', isActive ? 'page' : 'false');
+  });
+}
+
 function navigateTo(page) {
   currentPage = page;
   document.getElementById('app').dataset.page = page;
@@ -1370,6 +1376,7 @@ function navigateTo(page) {
   if (page === 'dashboard') renderDashboard();
   if (page === 'shop') renderCosmeticsCollection();
   if (page === 'settings') populateSettingsPage();
+  updateBottomNav();
 }
 
 // ── Board helpers ──────────────────────────────────────────
@@ -2330,15 +2337,6 @@ document.getElementById('btn-dashboard-new').addEventListener('click', () => {
   navigateTo('game');
 });
 
-document.getElementById('btn-dashboard-shop').addEventListener('click', () => {
-  navigateTo('shop');
-});
-document.getElementById('btn-dashboard-settings').addEventListener('click', () => {
-  navigateTo('settings');
-});
-document.getElementById('btn-dashboard-about').addEventListener('click', () => {
-  navigateTo('about');
-});
 document.getElementById('btn-dashboard-missions').addEventListener('click', () => {
   renderDailyMissions();
   showOverlay('ov-missions');
@@ -2347,17 +2345,13 @@ document.getElementById('btn-game-back').addEventListener('click', () => {
   saveCurrentGame();
   navigateTo('dashboard');
 });
-document.getElementById('btn-shop-back').addEventListener('click', () => {
-  navigateTo('dashboard');
-});
-document.getElementById('btn-settings-back').addEventListener('click', () => {
-  navigateTo('dashboard');
-});
-document.getElementById('btn-about-back').addEventListener('click', () => {
-  navigateTo('dashboard');
-});
 document.getElementById('btn-settings-shop').addEventListener('click', () => {
   navigateTo('shop');
+});
+document.querySelectorAll('.bottom-nav__item').forEach(button => {
+  button.addEventListener('click', () => {
+    navigateTo(button.dataset.navPage);
+  });
 });
 
 document.getElementById('btn-missions-close').addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
       <div class="page-scroll page-scroll--dashboard">
         <header class="page-top page-top--dashboard">
           <div>
-            <p class="page-kicker">Mobile puzzle dashboard</p>
+            <p class="page-kicker">Calm arcade puzzle</p>
             <h1>Burohame</h1>
             <p class="page-intro" id="dashboard-intro">Start a fresh run.</p>
           </div>
@@ -31,7 +31,7 @@
           </a>
         </header>
 
-        <section class="dash-hero">
+        <section class="dash-hero" aria-label="Start playing">
           <div class="dash-mark" aria-hidden="true">
             <span></span>
             <span></span>
@@ -41,6 +41,7 @@
             <button class="pill-btn wide" id="btn-dashboard-continue">Continue run</button>
             <button class="pill-btn wide pill-btn--secondary" id="btn-dashboard-new">Start new run</button>
           </div>
+          <p class="dash-hero-note">Equipped finish: <strong id="dashboard-finish">Classic</strong></p>
         </section>
 
         <section class="dashboard-stats" aria-label="Dashboard statistics">
@@ -56,35 +57,13 @@
             <span>Today</span>
             <strong id="dashboard-today">0</strong>
           </article>
-          <article class="dashboard-stat">
-            <span>Finish</span>
-            <strong id="dashboard-finish">Classic</strong>
-          </article>
         </section>
 
-        <section class="dashboard-links" aria-label="Dashboard destinations">
-          <button class="dash-link" id="btn-dashboard-shop" type="button">
-            <span class="dash-link__eyebrow">Page 3</span>
-            <strong>Shop</strong>
-            <span>Unlock and equip block finishes.</span>
-          </button>
-          <button class="dash-link" id="btn-dashboard-settings" type="button">
-            <span class="dash-link__eyebrow">Page 4</span>
-            <strong>Settings</strong>
-            <span>Tune difficulty, colour, theme and layout.</span>
-          </button>
-          <button class="dash-link" id="btn-dashboard-about" type="button">
-            <span class="dash-link__eyebrow">Page 5</span>
-            <strong>About and guide</strong>
-            <span>Learn the basics and find the project on GitHub.</span>
-          </button>
-          <button class="dash-link dash-link--mission" id="btn-dashboard-missions" type="button">
-            <span class="dashboard-mission-pill" id="mission-badge" hidden>0/0</span>
-            <span class="dash-link__eyebrow">Today</span>
-            <strong>Daily missions</strong>
-            <span id="dashboard-mission-copy">Fresh goals are on the way.</span>
-          </button>
-        </section>
+        <button class="dashboard-missions" id="btn-dashboard-missions" type="button" aria-label="Open daily missions">
+          <span class="dashboard-missions__label">Daily missions</span>
+          <strong id="dashboard-mission-copy">Fresh goals are on the way.</strong>
+          <span class="dashboard-mission-pill" id="mission-badge" hidden>0/0</span>
+        </button>
       </div>
     </section>
 
@@ -140,15 +119,10 @@
     <section class="page page--shop" data-page="shop" aria-label="Shop">
       <div class="page-scroll">
         <header class="page-top">
-          <button class="icon-btn" id="btn-shop-back" aria-label="Back to dashboard" type="button">
-            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-              <path d="M11.75 4.5L6 10l5.75 5.5" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-          </button>
           <div>
-            <p class="page-kicker">Page 3</p>
+            <p class="page-kicker">Collection</p>
             <h2>Shop</h2>
-            <p class="page-intro">Spend coins on block finishes you can equip for future runs.</p>
+            <p class="page-intro">Unlock finishes and equip one for your next run.</p>
           </div>
         </header>
 
@@ -168,15 +142,10 @@
     <section class="page page--settings" data-page="settings" aria-label="Settings">
       <div class="page-scroll">
         <header class="page-top">
-          <button class="icon-btn" id="btn-settings-back" aria-label="Back to dashboard" type="button">
-            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-              <path d="M11.75 4.5L6 10l5.75 5.5" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-          </button>
           <div>
-            <p class="page-kicker">Page 4</p>
+            <p class="page-kicker">Tune play</p>
             <h2>Settings</h2>
-            <p class="page-intro">Adjust how the game looks and how demanding each run feels.</p>
+            <p class="page-intro">Adjust how the game feels and looks.</p>
           </div>
         </header>
 
@@ -239,15 +208,10 @@
     <section class="page page--about" data-page="about" aria-label="About and guide">
       <div class="page-scroll">
         <header class="page-top">
-          <button class="icon-btn" id="btn-about-back" aria-label="Back to dashboard" type="button">
-            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-              <path d="M11.75 4.5L6 10l5.75 5.5" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-          </button>
           <div>
-            <p class="page-kicker">Page 5</p>
+            <p class="page-kicker">Guide</p>
             <h2>About and guide</h2>
-            <p class="page-intro">A quick tutorial, a few strategy notes, and where to find the project.</p>
+            <p class="page-intro">Learn the basics and find the project.</p>
           </div>
         </header>
 
@@ -349,6 +313,35 @@
       </div>
     </div>
 
+    <nav class="bottom-nav" aria-label="Primary">
+      <button class="bottom-nav__item" data-nav-page="dashboard" type="button" aria-label="Dashboard">
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+          <path d="M3.5 8.25L10 3l6.5 5.25V16a1 1 0 0 1-1 1h-3.75v-4.5h-3.5V17H4.5a1 1 0 0 1-1-1V8.25Z" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"/>
+        </svg>
+        <span>Home</span>
+      </button>
+      <button class="bottom-nav__item" data-nav-page="shop" type="button" aria-label="Shop">
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+          <path d="M5 7.25h10l-.75 9.25a1 1 0 0 1-1 .92H6.75a1 1 0 0 1-1-.92L5 7.25Z" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"/>
+          <path d="M7.5 7.25V6a2.5 2.5 0 1 1 5 0v1.25" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/>
+        </svg>
+        <span>Shop</span>
+      </button>
+      <button class="bottom-nav__item" data-nav-page="settings" type="button" aria-label="Settings">
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+          <circle cx="10" cy="10" r="2.6" stroke="currentColor" stroke-width="1.7"/>
+          <path d="M10 2.75v2.1M10 15.15v2.1M4.87 4.87l1.48 1.48M13.65 13.65l1.48 1.48M2.75 10h2.1M15.15 10h2.1M4.87 15.13l1.48-1.48M13.65 6.35l1.48-1.48" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+        </svg>
+        <span>Settings</span>
+      </button>
+      <button class="bottom-nav__item" data-nav-page="about" type="button" aria-label="Guide">
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+          <path d="M6 4.25h7.25a1.75 1.75 0 0 1 1.75 1.75v9.75H7.5A1.5 1.5 0 0 0 6 17.25V4.25Z" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"/>
+          <path d="M6 4.25v13m0 0h8.25" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/>
+        </svg>
+        <span>Guide</span>
+      </button>
+    </nav>
   </div>
 
   <script src="app.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -136,11 +136,15 @@ html, body {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: 18px 16px 24px;
+  padding: 18px 16px calc(110px + env(safe-area-inset-bottom, 0px));
 }
 
 .page-scroll--dashboard {
   padding-top: 20px;
+}
+
+.page--game #main {
+  padding-bottom: 12px;
 }
 
 .page-top {
@@ -148,15 +152,6 @@ html, body {
   align-items: flex-start;
   gap: 12px;
   margin-bottom: 18px;
-}
-
-.page-top .icon-btn {
-  width: 40px;
-  height: 40px;
-  border: 1px solid color-mix(in srgb, var(--accent) 14%, var(--border));
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--accent) 6%, var(--bg-card));
-  color: color-mix(in srgb, var(--accent-dk) 76%, var(--text));
 }
 
 .page-top > div {
@@ -199,7 +194,7 @@ html, body {
 }
 
 .dash-hero {
-  padding: 20px 18px;
+  padding: 20px 18px 16px;
   border-radius: 28px;
   background:
     radial-gradient(circle at top right, color-mix(in srgb, var(--accent) 18%, transparent), transparent 48%),
@@ -232,86 +227,80 @@ html, body {
   margin-top: 0;
 }
 
+.dash-hero-note {
+  margin-top: 12px;
+  font-size: 13px;
+  color: var(--text-2);
+}
+
+.dash-hero-note strong {
+  color: var(--text);
+}
+
 .dashboard-stats {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
   margin-top: 14px;
 }
 
 .dashboard-stat {
-  padding: 13px 14px;
+  padding: 12px 10px;
   border-radius: 18px;
-  background: var(--bg-card);
-  border: 1px solid color-mix(in srgb, var(--accent) 12%, var(--border));
+  background: color-mix(in srgb, var(--accent) 4%, var(--bg-card));
+  border: 1px solid color-mix(in srgb, var(--accent) 10%, var(--border));
 }
 
 .dashboard-stat span {
   display: block;
-  font-size: 12px;
+  font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.06em;
   color: var(--text-2);
 }
 
 .dashboard-stat strong {
   display: block;
-  margin-top: 7px;
-  font-size: 24px;
+  margin-top: 8px;
+  font-size: clamp(22px, 6vw, 26px);
   line-height: 1;
   color: var(--text);
 }
 
-.dashboard-links {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  margin-top: 16px;
-}
-
-.dash-link {
+.dashboard-missions {
   position: relative;
   width: 100%;
-  padding: 14px 16px;
+  margin-top: 16px;
+  padding: 14px 48px 14px 16px;
   border-radius: 20px;
-  border: 1px solid color-mix(in srgb, var(--accent) 12%, var(--border));
-  background: var(--bg-card);
+  border: 1px solid color-mix(in srgb, var(--accent) 14%, var(--border));
+  background: color-mix(in srgb, var(--accent) 7%, var(--bg-card));
   color: inherit;
   text-align: left;
   cursor: pointer;
 }
 
-.dash-link__eyebrow {
+.dashboard-missions__label {
   display: block;
   font-size: 11px;
   font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 0.07em;
+  letter-spacing: 0.08em;
   color: color-mix(in srgb, var(--accent-dk) 62%, var(--text-2));
 }
 
-.dash-link strong {
+.dashboard-missions strong {
   display: block;
   margin-top: 4px;
-  font-size: 18px;
-}
-
-.dash-link span:last-child {
-  display: block;
-  margin-top: 6px;
-  font-size: 13px;
+  font-size: 15px;
   line-height: 1.4;
-  color: var(--text-2);
-}
-
-.dash-link--mission {
-  background: color-mix(in srgb, var(--accent) 8%, var(--bg-card));
 }
 
 .dashboard-mission-pill {
   position: absolute;
-  top: 12px;
-  right: 12px;
+  top: 50%;
+  right: 14px;
+  transform: translateY(-50%);
   min-width: 36px;
   padding: 4px 8px;
   border-radius: 999px;
@@ -352,6 +341,56 @@ html, body {
 }
 a.icon-btn { text-decoration: none; }
 .icon-btn:active { opacity: 0.6; }
+
+.bottom-nav {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: calc(12px + env(safe-area-inset-bottom, 0px));
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  padding: 8px;
+  border-radius: 22px;
+  background: color-mix(in srgb, var(--bg-card) 88%, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--accent) 10%, var(--border));
+  box-shadow: 0 10px 30px rgba(0,0,0,0.08);
+  backdrop-filter: blur(14px);
+}
+
+#app[data-page="game"] .bottom-nav {
+  display: none;
+}
+
+.bottom-nav__item {
+  border: 0;
+  background: transparent;
+  color: var(--text-2);
+  border-radius: 16px;
+  padding: 10px 6px 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font: inherit;
+  cursor: pointer;
+}
+
+.bottom-nav__item span {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.bottom-nav__item.is-active {
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg-card));
+  color: color-mix(in srgb, var(--accent-dk) 76%, var(--text));
+}
+
+.bottom-nav__item:active {
+  opacity: 0.75;
+}
 
 .mission-btn {
   position: relative;


### PR DESCRIPTION
### Motivation
- Make the app feel more mobile-first and thumb-friendly by replacing page-card navigation with a persistent bottom navigation and reduce redundant dashboard copy and controls. 
- Surface the most important dashboard actions and metrics (start/continue/run finish) so users can start a run with one tap. 
- Reduce visual clutter by removing duplicated back buttons and page-card links in favor of a single navigation pattern.

### Description
- Added a design context file `.impeccable.md` with brand, aesthetic direction and design principles. 
- Introduced a new persistent bottom navigation in `index.html` with four nav buttons and corresponding styles in `styles.css`, and hid the nav on the game page. 
- Added `updateBottomNav()` and wired it into `navigateTo()` in `app.js`, and attached click handlers to `.bottom-nav__item` to drive page navigation; removed individual dashboard/shop/settings/about button handlers and redundant back buttons. 
- Simplified dashboard UI text and layout: updated hero copy, condensed mission copy, moved the equipped finish label into the hero, and adjusted padding/layout CSS (including safe-area bottom padding) and dashboard stat grid.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c010e4209c833381a731946abeafd7)