### PR TITLE
Add shared daily challenge and streak system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,12 +22,16 @@ When you are asked to make repository changes, follow this sequence unless the u
 
 When a user says "implement the next issue", inspect the lists below, pick the first item in `TODO`, implement it, and then move it to `Completed` once the work has landed.
 
-### TODO
+After implementing an issue, also tidy the GitHub issue queue so the repository and this file stay aligned:
+- close the implemented GitHub issue once the branch, commit, push, and PR are in place;
+- remove it from `TODO` here and add it to `Completed`;
+- if `TODO` becomes empty, add the next suitable open GitHub issue to `TODO` before the next implementation request.
 
-1. [#38 Add a daily challenge and streak system](https://github.com/Bigalan09/Burohame/issues/38)
+### TODO
 
 ### Completed
 
+- [#38 Add a daily challenge and streak system](https://github.com/Bigalan09/Burohame/issues/38)
 - [#37 Add delight feedback for milestone moments](https://github.com/Bigalan09/Burohame/issues/37)
 - [#36 Add a cosmetics collection and unlock flow](https://github.com/Bigalan09/Burohame/issues/36)
 - [#34 Add a post-run rewards summary](https://github.com/Bigalan09/Burohame/issues/34)

--- a/app.js
+++ b/app.js
@@ -181,12 +181,24 @@ let progressionState = null;
 let coinToastOffset = 0;
 let runSummary = null;
 let currentPage = 'dashboard';
+let currentSessionType = 'standard';
+let dailyChallengeState = {
+  date: '',
+  seed: 0,
+  targetScore: 0,
+  randomState: 0,
+};
 
 const COLOR_NAMES = ['orange','blue','green','purple','red','teal','pink'];
 const PROGRESSION_STORAGE_KEY = 'bst-progression';
 const GAME_SESSION_STORAGE_KEY = 'bst-current-run';
-const PROGRESSION_STATE_VERSION = 2;
+const PROGRESSION_STATE_VERSION = 3;
 const REDUCED_MOTION_QUERY = window.matchMedia('(prefers-reduced-motion: reduce)');
+const DAILY_CHALLENGE_REWARD_BASE = 12;
+const DAILY_CHALLENGE_STREAK_STEP = 2;
+const DAILY_CHALLENGE_STREAK_BONUS_CAP = 10;
+const DAILY_CHALLENGE_TARGET_MIN = 140;
+const DAILY_CHALLENGE_TARGET_RANGE = 51;
 const COIN_REWARDS = Object.freeze({
   clearRegion: 0,
   multiClearBonus: 0,
@@ -330,6 +342,16 @@ function getLocalDateKey(date = new Date()) {
   return `${year}-${month}-${day}`;
 }
 
+function getUTCDateKey(date = new Date()) {
+  return date.toISOString().slice(0, 10);
+}
+
+function getPreviousDateKey(dateKey) {
+  const date = new Date(`${dateKey}T00:00:00Z`);
+  date.setUTCDate(date.getUTCDate() - 1);
+  return getUTCDateKey(date);
+}
+
 function hashString(value) {
   let hash = 2166136261;
   for (let i = 0; i < value.length; i++) {
@@ -337,6 +359,45 @@ function hashString(value) {
     hash = Math.imul(hash, 16777619);
   }
   return hash >>> 0;
+}
+
+function getDailyChallengeSeed(dateKey) {
+  return hashString(`daily-challenge:${dateKey}`);
+}
+
+function getDailyChallengeTarget(seed) {
+  return DAILY_CHALLENGE_TARGET_MIN + (seed % DAILY_CHALLENGE_TARGET_RANGE);
+}
+
+function isDailyChallengeSession() {
+  return currentSessionType === 'daily';
+}
+
+function randomValue() {
+  if (!isDailyChallengeSession()) return Math.random();
+  const currentState = dailyChallengeState.randomState || dailyChallengeState.seed || 1;
+  dailyChallengeState.randomState = (Math.imul(currentState, 1664525) + 1013904223) >>> 0;
+  return dailyChallengeState.randomState / 4294967296;
+}
+
+function resetStandardSessionState() {
+  currentSessionType = 'standard';
+  dailyChallengeState = {
+    date: '',
+    seed: 0,
+    targetScore: 0,
+    randomState: 0,
+  };
+}
+
+function configureDailyChallengeSession(dailyState, options = {}) {
+  currentSessionType = 'daily';
+  dailyChallengeState = {
+    date: dailyState.date,
+    seed: dailyState.seed,
+    targetScore: dailyState.targetScore,
+    randomState: clampWholeNumber(options.randomState, dailyState.seed || 1) || (dailyState.seed || 1),
+  };
 }
 
 function createDailyMissionEntry(template, dateKey) {
@@ -407,6 +468,15 @@ function createDefaultProgressionState() {
       claimedIds: [],
       refreshCount: 0,
     },
+    dailyChallenge: {
+      date: '',
+      seed: 0,
+      targetScore: 0,
+      bestScore: 0,
+      completedAt: '',
+      attempts: 0,
+      rewardClaimedDate: '',
+    },
     streak: {
       current: 0,
       best: 0,
@@ -430,6 +500,19 @@ function sanitiseMissionState(value) {
     completedIds: uniqueStringList(src.completedIds, []),
     claimedIds: uniqueStringList(src.claimedIds, []),
     refreshCount: clampWholeNumber(src.refreshCount, 0),
+  };
+}
+
+function sanitiseDailyChallengeState(value) {
+  const src = value && typeof value === 'object' ? value : {};
+  return {
+    date: typeof src.date === 'string' ? src.date : '',
+    seed: clampWholeNumber(src.seed, 0),
+    targetScore: clampWholeNumber(src.targetScore, 0),
+    bestScore: clampWholeNumber(src.bestScore, 0),
+    completedAt: typeof src.completedAt === 'string' ? src.completedAt : '',
+    attempts: clampWholeNumber(src.attempts, 0),
+    rewardClaimedDate: typeof src.rewardClaimedDate === 'string' ? src.rewardClaimedDate : '',
   };
 }
 
@@ -473,6 +556,7 @@ function sanitiseProgressionState(rawState) {
       ownedBlockSkins,
     },
     dailyMissions: sanitiseMissionState(src.dailyMissions),
+    dailyChallenge: sanitiseDailyChallengeState(src.dailyChallenge),
     streak: {
       current: clampWholeNumber(streak.current, defaults.streak.current),
       best: clampWholeNumber(streak.best, defaults.streak.best),
@@ -585,12 +669,39 @@ function renderGameOverSummary() {
   const objectives = getCompletedRunObjectives();
   const objectivesList = document.getElementById('go-objectives-list');
   const objectiveCount = document.getElementById('go-objective-count');
+  const intro = document.querySelector('.summary-intro');
+  const dailySummary = document.getElementById('go-daily-summary');
+  const dailyStatus = document.getElementById('go-daily-status');
+  const dailyCopy = document.getElementById('go-daily-copy');
+  const nextRunButton = document.getElementById('btn-new');
 
   document.getElementById('go-score').textContent = String(summary.finalScore);
   document.getElementById('go-best').textContent = String(bestScore);
   document.getElementById('go-coins-earned').textContent = `+${summary.coinsEarned}`;
   document.getElementById('go-coin-total').textContent = String(getCoinBalance());
   objectiveCount.textContent = objectives.length === 1 ? '1 cleared' : `${objectives.length} cleared`;
+  if (intro) {
+    intro.textContent = isDailyChallengeSession()
+      ? 'Your daily challenge result is locked in.'
+      : 'Your run rewards are ready.';
+  }
+  if (nextRunButton) {
+    nextRunButton.textContent = isDailyChallengeSession() ? 'Play another run' : 'Start next run';
+  }
+
+  if (dailySummary && dailyStatus && dailyCopy) {
+    if (isDailyChallengeSession()) {
+      const challenge = ensureDailyChallengeForToday();
+      const complete = challenge.completedAt === challenge.date;
+      dailySummary.hidden = false;
+      dailyStatus.textContent = complete ? 'Completed' : 'Missed';
+      dailyCopy.textContent = complete
+        ? `Target ${challenge.targetScore} reached. Best score ${Math.max(challenge.bestScore, summary.finalScore)}.`
+        : `Target ${challenge.targetScore}. Best score ${Math.max(challenge.bestScore, summary.finalScore)}.`;
+    } else {
+      dailySummary.hidden = true;
+    }
+  }
 
   objectivesList.innerHTML = '';
   if (!objectives.length) {
@@ -824,6 +935,155 @@ function ensureDailyMissionsForToday() {
   });
 
   return nextState.dailyMissions;
+}
+
+function syncDisplayedStreak() {
+  const todayKey = getUTCDateKey();
+  const yesterdayKey = getPreviousDateKey(todayKey);
+
+  updateProgressionState(state => {
+    if (state.streak.lastActiveDate && ![todayKey, yesterdayKey].includes(state.streak.lastActiveDate)) {
+      state.streak.current = 0;
+    }
+    return state;
+  });
+}
+
+function ensureDailyChallengeForToday() {
+  const todayKey = getUTCDateKey();
+  const challengeSeed = getDailyChallengeSeed(todayKey);
+  const targetScore = getDailyChallengeTarget(challengeSeed);
+
+  syncDisplayedStreak();
+
+  const existing = progressionState?.dailyChallenge;
+  if (existing?.date === todayKey && existing.seed === challengeSeed && existing.targetScore === targetScore) {
+    return existing;
+  }
+
+  const nextState = updateProgressionState(state => {
+    const previous = sanitiseDailyChallengeState(state.dailyChallenge);
+    state.dailyChallenge = {
+      date: todayKey,
+      seed: challengeSeed,
+      targetScore,
+      bestScore: previous.date === todayKey ? previous.bestScore : 0,
+      completedAt: previous.date === todayKey ? previous.completedAt : '',
+      attempts: previous.date === todayKey ? previous.attempts : 0,
+      rewardClaimedDate: previous.date === todayKey ? previous.rewardClaimedDate : '',
+    };
+    return state;
+  });
+
+  return nextState.dailyChallenge;
+}
+
+function getDisplayedStreakCount() {
+  const streak = progressionState?.streak;
+  if (!streak) return 0;
+  const todayKey = getUTCDateKey();
+  const yesterdayKey = getPreviousDateKey(todayKey);
+  if (streak.lastActiveDate && ![todayKey, yesterdayKey].includes(streak.lastActiveDate)) return 0;
+  return streak.current;
+}
+
+function getDailyChallengeRewardAmount(streakCount) {
+  return DAILY_CHALLENGE_REWARD_BASE + Math.min(
+    DAILY_CHALLENGE_STREAK_BONUS_CAP,
+    Math.max(0, streakCount - 1) * DAILY_CHALLENGE_STREAK_STEP
+  );
+}
+
+function getDailyChallengeStatus(challenge = ensureDailyChallengeForToday()) {
+  const displayedStreak = getDisplayedStreakCount();
+  const complete = challenge.completedAt === challenge.date;
+  const remaining = Math.max(0, challenge.targetScore - challenge.bestScore);
+  const reward = getDailyChallengeRewardAmount(complete ? displayedStreak : Math.max(1, displayedStreak || 1));
+  return {
+    complete,
+    remaining,
+    reward,
+    streak: displayedStreak,
+  };
+}
+
+function getDailyChallengeBestLabel(challenge) {
+  if (!challenge.bestScore) return 'Best 0';
+  return `Best ${challenge.bestScore}`;
+}
+
+function markDailyChallengeAttempt() {
+  if (!isDailyChallengeSession()) return;
+  const todayChallenge = ensureDailyChallengeForToday();
+  updateProgressionState(state => {
+    if (state.dailyChallenge.date === todayChallenge.date) {
+      state.dailyChallenge.attempts += 1;
+    }
+    return state;
+  });
+}
+
+function maybeCompleteDailyChallenge() {
+  if (!isDailyChallengeSession()) return;
+
+  const challenge = ensureDailyChallengeForToday();
+  if (challenge.completedAt === challenge.date || score < challenge.targetScore) return;
+
+  const todayKey = challenge.date;
+  const yesterdayKey = getPreviousDateKey(todayKey);
+  let streakCount = 1;
+
+  updateProgressionState(state => {
+    state.dailyChallenge.bestScore = Math.max(state.dailyChallenge.bestScore, score);
+    state.dailyChallenge.completedAt = todayKey;
+
+    if (state.streak.lastActiveDate === todayKey) {
+      streakCount = Math.max(1, state.streak.current);
+    } else if (state.streak.lastActiveDate === yesterdayKey) {
+      streakCount = state.streak.current + 1;
+      state.streak.current = streakCount;
+      state.streak.lastActiveDate = todayKey;
+    } else {
+      streakCount = 1;
+      state.streak.current = 1;
+      state.streak.lastActiveDate = todayKey;
+    }
+
+    state.streak.best = Math.max(state.streak.best, state.streak.current);
+    return state;
+  });
+
+  const rewardAmount = getDailyChallengeRewardAmount(streakCount);
+  updateProgressionState(state => {
+    state.dailyChallenge.rewardClaimedDate = todayKey;
+    return state;
+  });
+  awardCoins(rewardAmount, `Daily challenge day ${streakCount}`, {
+    celebrate: true,
+    major: streakCount >= 3,
+  });
+  showMilestoneMoment({
+    eyebrow: `Daily challenge cleared`,
+    title: `Target ${challenge.targetScore} reached`,
+    detail: `Streak ${streakCount}. +${rewardAmount} coins added.`,
+    major: streakCount >= 3,
+    anchor: '#score-wrap',
+    announce: `Daily challenge complete. ${rewardAmount} coins awarded. ${streakCount} day streak.`,
+  });
+  renderDashboard();
+}
+
+function syncDailyChallengeScoreProgress() {
+  if (!isDailyChallengeSession()) return;
+  const challenge = ensureDailyChallengeForToday();
+  if (score <= challenge.bestScore) return;
+
+  updateProgressionState(state => {
+    if (state.dailyChallenge.date === challenge.date) {
+      state.dailyChallenge.bestScore = Math.max(state.dailyChallenge.bestScore, score);
+    }
+    return state;
+  });
 }
 
 function getDailyMissionProgressText(mission) {
@@ -1091,7 +1351,7 @@ function orderMatters() {
 }
 
 function randomPiece() {
-  return PIECE_DEFS[Math.floor(Math.random() * PIECE_DEFS.length)];
+  return PIECE_DEFS[Math.floor(randomValue() * PIECE_DEFS.length)];
 }
 
 // ── Difficulty-weighted piece selection ────────────────────
@@ -1107,7 +1367,7 @@ function weightedRandomPiece() {
     totalWeight += w;
     return w;
   });
-  let rand = Math.random() * totalWeight;
+  let rand = randomValue() * totalWeight;
   for (let i = 0; i < PIECE_DEFS.length; i++) {
     rand -= weights[i];
     if (rand <= 0) return PIECE_DEFS[i];
@@ -1147,7 +1407,7 @@ function canCauseClearOnBoard(cells, b) {
 function earlyPiece() {
   const pool = PIECE_DEFS.filter(p => p.length >= 3 && p.length <= 4);
   if (pool.length === 0) return weightedRandomPiece();
-  return pool[Math.floor(Math.random() * pool.length)];
+  return pool[Math.floor(randomValue() * pool.length)];
 }
 
 // Verify the next `rounds` future rounds will still have clearing opportunities.
@@ -1224,8 +1484,8 @@ function smartPieces() {
       }
     }
     if (candidates.length > 0) {
-      const slot = Math.floor(Math.random() * rackSize);
-      p[slot] = candidates[Math.floor(Math.random() * candidates.length)];
+      const slot = Math.floor(randomValue() * rackSize);
+      p[slot] = candidates[Math.floor(randomValue() * candidates.length)];
     }
   }
 
@@ -1299,6 +1559,15 @@ function createGameSessionSnapshot() {
     score,
     combo,
     rackSize,
+    sessionType: currentSessionType,
+    dailyChallenge: isDailyChallengeSession()
+      ? {
+          date: dailyChallengeState.date,
+          seed: dailyChallengeState.seed,
+          targetScore: dailyChallengeState.targetScore,
+          randomState: dailyChallengeState.randomState,
+        }
+      : null,
     runSummary: ensureRunSummary(),
   };
 }
@@ -1355,6 +1624,15 @@ function getSavedGameSession() {
       score: clampWholeNumber(raw.score, 0),
       combo: clampWholeNumber(raw.combo, 0),
       rackSize: savedRackSize,
+      sessionType: raw.sessionType === 'daily' ? 'daily' : 'standard',
+      dailyChallenge: raw.dailyChallenge && typeof raw.dailyChallenge === 'object'
+        ? {
+            date: typeof raw.dailyChallenge.date === 'string' ? raw.dailyChallenge.date : '',
+            seed: clampWholeNumber(raw.dailyChallenge.seed, 0),
+            targetScore: clampWholeNumber(raw.dailyChallenge.targetScore, 0),
+            randomState: clampWholeNumber(raw.dailyChallenge.randomState, 0),
+          }
+        : null,
       runSummary: raw.runSummary && typeof raw.runSummary === 'object'
         ? {
             finalScore: clampWholeNumber(raw.runSummary.finalScore, 0),
@@ -1377,6 +1655,16 @@ function getSavedGameSession() {
 function restoreSavedGame() {
   const saved = getSavedGameSession();
   if (!saved) return false;
+  if (saved.sessionType === 'daily') {
+    const todayChallenge = ensureDailyChallengeForToday();
+    if (!saved.dailyChallenge || saved.dailyChallenge.date !== todayChallenge.date) {
+      clearSavedGame();
+      return false;
+    }
+    configureDailyChallengeSession(todayChallenge, { randomState: saved.dailyChallenge.randomState });
+  } else {
+    resetStandardSessionState();
+  }
 
   rackSize = saved.rackSize;
   board = saved.board;
@@ -1394,7 +1682,20 @@ function restoreSavedGame() {
   updateRackPlayability();
   updateTrainingPanel();
   updateScoreUI();
+  renderDashboard();
   return true;
+}
+
+function renderSessionModeBadge() {
+  const badge = document.getElementById('session-mode-badge');
+  if (!badge) return;
+
+  if (isDailyChallengeSession()) {
+    badge.hidden = false;
+    badge.textContent = `Daily · target ${dailyChallengeState.targetScore}`;
+  } else {
+    badge.hidden = true;
+  }
 }
 
 function renderDashboard() {
@@ -1402,30 +1703,70 @@ function renderDashboard() {
   const newGameBtn = document.getElementById('btn-dashboard-new');
   const intro = document.getElementById('dashboard-intro');
   const missionCopy = document.getElementById('dashboard-mission-copy');
+  const dailyTitle = document.getElementById('daily-challenge-title');
+  const dailyCopy = document.getElementById('daily-challenge-copy');
+  const dailyTarget = document.getElementById('daily-challenge-target');
+  const dailyBest = document.getElementById('daily-challenge-best');
+  const dailyButton = document.getElementById('btn-dashboard-daily');
+  const dailyInfoButton = document.getElementById('btn-dashboard-daily-info');
+  const dailyStreakPill = document.getElementById('daily-streak-pill');
   const hasSavedGame = !!getSavedGameSession();
+  const savedGame = getSavedGameSession();
   const missionCounts = getDailyMissionCounts();
   const skin = BLOCK_SKIN_LOOKUP[getEquippedBlockSkin()] || BLOCK_SKIN_LOOKUP.classic;
+  const challenge = ensureDailyChallengeForToday();
+  const challengeStatus = getDailyChallengeStatus(challenge);
 
   if (continueBtn) {
     continueBtn.hidden = !hasSavedGame;
     continueBtn.disabled = !hasSavedGame;
+    continueBtn.textContent = savedGame?.sessionType === 'daily' ? 'Continue daily challenge' : 'Continue run';
   }
   if (newGameBtn) {
     newGameBtn.textContent = hasSavedGame ? 'Start fresh run' : 'Start new run';
   }
   if (intro) {
-    intro.textContent = hasSavedGame ? 'Pick up where you left off.' : 'One tap to start playing.';
+    if (savedGame?.sessionType === 'daily') {
+      intro.textContent = 'Your daily challenge is still waiting.';
+    } else {
+      intro.textContent = hasSavedGame ? 'Pick up where you left off.' : 'One tap to start playing.';
+    }
   }
   if (missionCopy) {
     missionCopy.textContent = missionCounts.total
       ? `${missionCounts.completed} of ${missionCounts.total} done today`
       : 'Fresh goals are on the way.';
   }
+  if (dailyTitle) {
+    dailyTitle.textContent = challengeStatus.complete
+      ? 'Today cleared'
+      : `Target ${challenge.targetScore}`;
+  }
+  if (dailyCopy) {
+    dailyCopy.textContent = challengeStatus.complete
+      ? `Completed on ${challenge.date}. Come back tomorrow to keep the streak alive.`
+      : challengeStatus.remaining
+        ? `${challengeStatus.remaining} points left to finish today’s shared seed.`
+        : 'A fresh seeded board is ready.';
+  }
+  if (dailyTarget) dailyTarget.textContent = `Target ${challenge.targetScore}`;
+  if (dailyBest) dailyBest.textContent = getDailyChallengeBestLabel(challenge);
+  if (dailyButton) {
+    dailyButton.textContent = challengeStatus.complete ? 'Replay daily challenge' : 'Play daily challenge';
+  }
+  if (dailyInfoButton) {
+    dailyInfoButton.textContent = `${challengeStatus.reward} coin reward`;
+  }
+  if (dailyStreakPill) {
+    const dayLabel = challengeStatus.streak === 1 ? 'day' : 'days';
+    dailyStreakPill.textContent = `🔥 ${challengeStatus.streak} ${dayLabel} streak`;
+  }
 
   document.getElementById('dashboard-coins').textContent = String(getCoinBalance());
   document.getElementById('dashboard-best').textContent = String(bestScore);
   document.getElementById('dashboard-today').textContent = String(todayScore);
   document.getElementById('dashboard-finish').textContent = skin.name;
+  renderSessionModeBadge();
 }
 
 function populateQuickSettings() {
@@ -1960,6 +2301,8 @@ function triggerGameOver() {
   gameOver = true;
   clearSavedGame();
 
+  syncDailyChallengeScoreProgress();
+
   const isNewBest = score > bestScore;
   if (isNewBest) {
     bestScore = score;
@@ -1975,6 +2318,7 @@ function triggerGameOver() {
   todayScore = (td.d === todayKey) ? Math.max(td.s, score) : score;
   localStorage.setItem('bst-today', JSON.stringify({ d: todayKey, s: todayScore }));
   updateScoreUI();
+  maybeCompleteDailyChallenge();
   evaluateRunObjectives();
   updateDailyMissionProgress('runs', 1);
 
@@ -2052,7 +2396,15 @@ function newRound() {
   }
 }
 
-function startNewGame() {
+function startNewGame(options = {}) {
+  if (options.sessionType === 'daily') {
+    const challenge = ensureDailyChallengeForToday();
+    configureDailyChallengeSession(challenge, { randomState: challenge.seed });
+    markDailyChallengeAttempt();
+  } else {
+    resetStandardSessionState();
+  }
+
   board    = emptyBoard();
   score    = 0;
   combo    = 0;
@@ -2085,6 +2437,9 @@ function updateScoreUI() {
   document.getElementById('today-val').textContent  = Math.max(todayScore, score);
   document.getElementById('best-val').textContent   = Math.max(bestScore, score);
   updateCoinUI();
+  syncDailyChallengeScoreProgress();
+  maybeCompleteDailyChallenge();
+  renderSessionModeBadge();
 
   // Bump animation when score changes
   if (String(score) !== prev) {
@@ -2458,6 +2813,14 @@ document.getElementById('btn-dashboard-new').addEventListener('click', () => {
   startNewGame();
   navigateTo('game');
 });
+document.getElementById('btn-dashboard-daily').addEventListener('click', () => {
+  startNewGame({ sessionType: 'daily' });
+  navigateTo('game');
+});
+document.getElementById('btn-dashboard-daily-info').addEventListener('click', () => {
+  const challenge = ensureDailyChallengeForToday();
+  alert(`Today’s daily challenge is shared worldwide for ${challenge.date}. Reach ${challenge.targetScore} points to keep your streak and earn a coin bonus.`);
+});
 
 document.getElementById('btn-dashboard-missions').addEventListener('click', () => {
   renderDailyMissions();
@@ -2552,6 +2915,7 @@ document.getElementById('btn-new').addEventListener('click', () => {
 document.addEventListener('visibilitychange', () => {
   if (document.visibilityState !== 'visible') return;
   renderDailyMissions();
+  ensureDailyChallengeForToday();
   renderCosmeticsCollection();
   renderDashboard();
 });
@@ -2570,6 +2934,8 @@ function init() {
 
   loadProgressionState();
   ensureDailyMissionsForToday();
+  ensureDailyChallengeForToday();
+  resetStandardSessionState();
   updateCoinUI();
   applyEquippedCosmeticSkin();
   loadSettings();

--- a/index.html
+++ b/index.html
@@ -59,6 +59,25 @@
           </article>
         </section>
 
+        <section class="dashboard-challenge" aria-label="Daily challenge">
+          <div class="dashboard-challenge__head">
+            <div>
+              <span class="dashboard-challenge__kicker">Shared daily challenge</span>
+              <h2 id="daily-challenge-title">Ready for today</h2>
+            </div>
+            <span class="dashboard-challenge__streak" id="daily-streak-pill">🔥 0 day streak</span>
+          </div>
+          <p class="dashboard-challenge__copy" id="daily-challenge-copy">A fresh seeded board is ready.</p>
+          <div class="dashboard-challenge__meta">
+            <span id="daily-challenge-target">Target 0</span>
+            <span id="daily-challenge-best">Best 0</span>
+          </div>
+          <div class="dashboard-challenge__actions">
+            <button class="pill-btn" id="btn-dashboard-daily" type="button">Play daily challenge</button>
+            <button class="pill-btn pill-btn--secondary" id="btn-dashboard-daily-info" type="button">How it works</button>
+          </div>
+        </section>
+
         <button class="dashboard-missions" id="btn-dashboard-missions" type="button" aria-label="Open daily missions">
           <span class="dashboard-missions__label">Daily missions</span>
           <strong id="dashboard-mission-copy">Fresh goals are on the way.</strong>
@@ -77,6 +96,7 @@
         <div id="score-wrap">
           <div id="score-main">0</div>
           <div id="score-sub">
+            <span id="session-mode-badge" class="session-mode-badge" hidden>Daily challenge</span>
             <span>Today&nbsp;<span id="today-val">0</span></span>
             <span>🏆&nbsp;<span id="best-val">0</span></span>
             <span class="coins-stat" aria-live="polite" aria-label="Coins">🪙&nbsp;<span id="coin-balance">0</span></span>
@@ -308,6 +328,13 @@
             <span id="go-objective-count" class="run-objectives__count">0 cleared</span>
           </div>
           <ul id="go-objectives-list" class="run-objectives__list"></ul>
+        </section>
+        <section class="summary-challenge" id="go-daily-summary" hidden>
+          <div class="summary-challenge__head">
+            <h3>Daily challenge</h3>
+            <span id="go-daily-status">In progress</span>
+          </div>
+          <p id="go-daily-copy">Today’s target is still waiting for you.</p>
         </section>
         <button class="pill-btn wide summary-primary-btn" id="btn-new" type="button">Start next run</button>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -311,6 +311,88 @@ html, body {
   line-height: 1;
 }
 
+.dashboard-challenge {
+  margin-top: 16px;
+  padding: 18px 16px;
+  border-radius: 24px;
+  background:
+    radial-gradient(circle at top right, color-mix(in srgb, var(--accent) 18%, transparent), transparent 54%),
+    linear-gradient(180deg, color-mix(in srgb, var(--accent) 10%, var(--bg-card)) 0%, color-mix(in srgb, var(--accent) 4%, var(--bg-card)) 100%);
+  border: 1px solid color-mix(in srgb, var(--accent) 18%, var(--border));
+}
+
+.dashboard-challenge__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.dashboard-challenge__kicker {
+  display: block;
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: color-mix(in srgb, var(--accent-dk) 62%, var(--text-2));
+}
+
+.dashboard-challenge h2 {
+  margin-top: 6px;
+  font-size: clamp(24px, 6vw, 30px);
+  line-height: 0.98;
+  letter-spacing: -0.04em;
+}
+
+.dashboard-challenge__streak {
+  flex-shrink: 0;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 18%, var(--bg-card));
+  border: 1px solid color-mix(in srgb, var(--accent) 20%, var(--border));
+  font-size: 12px;
+  font-weight: 800;
+  color: color-mix(in srgb, var(--accent-dk) 78%, var(--text));
+}
+
+.dashboard-challenge__copy {
+  margin-top: 12px;
+  font-size: 14px;
+  line-height: 1.45;
+  color: var(--text-2);
+}
+
+.dashboard-challenge__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.dashboard-challenge__meta span,
+.session-mode-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg-card));
+  border: 1px solid color-mix(in srgb, var(--accent) 18%, var(--border));
+  color: color-mix(in srgb, var(--accent-dk) 74%, var(--text));
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.dashboard-challenge__actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.dashboard-challenge__actions .pill-btn {
+  flex: 1;
+}
+
 /* ===== Header ===== */
 #hdr {
   display: flex;
@@ -448,6 +530,10 @@ a.icon-btn { text-decoration: none; }
 
 [data-theme="dark"] .coins-stat {
   color: color-mix(in srgb, var(--accent-hi) 72%, var(--text));
+}
+
+.session-mode-badge {
+  order: -1;
 }
 
 /* ===== Main ===== */
@@ -1294,6 +1380,40 @@ a.icon-btn { text-decoration: none; }
   padding-block: 14px;
 }
 
+.summary-challenge {
+  margin-top: 14px;
+  padding: 14px;
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--accent) 14%, var(--border));
+}
+
+.summary-challenge__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.summary-challenge__head h3 {
+  font-size: 15px;
+}
+
+.summary-challenge__head span {
+  font-size: 12px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: color-mix(in srgb, var(--accent-dk) 74%, var(--text));
+}
+
+.summary-challenge p {
+  margin-top: 8px;
+  margin-bottom: 0;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
 .missions-head {
   display: flex;
   align-items: flex-start;
@@ -1774,6 +1894,17 @@ input:checked + .tog-track .tog-thumb { transform: translateX(20px); }
   .cosmetic-card__preview {
     grid-template-columns: repeat(3, minmax(0, 1fr));
     min-height: auto;
+  }
+}
+
+@media (max-width: 360px) {
+  .dashboard-challenge__head,
+  .dashboard-challenge__actions {
+    flex-direction: column;
+  }
+
+  .dashboard-challenge__actions .pill-btn {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Introduce a single shared daily challenge to increase retention and give players a common seeded target to compete on each UTC day. 
- Track completion and a light streak so consecutive daily clears grant escalating coin rewards and give players a small reason to return. 
- Keep the agent workflow and issue queue aligned by updating the local `AGENTS.md` instructions so implemented issues are tidied in the repository and on GitHub.

### Description
- Implemented a deterministic UTC daily seed and target calculation and persisted daily challenge state inside the existing progression store, including `bestScore`, `attempts`, `completedAt` and reward tracking, and bumped `PROGRESSION_STATE_VERSION` to `3`.
- Added daily-session support and deterministic PRNG for daily runs so the shared seed produces reproducible piece selection, wired into session save/restore and the run snapshot format so a daily run can be resumed safely the same day.
- Wired up UI surfaces and styles: a dashboard daily challenge card and streak pill, an in-run session badge, and a game-over daily summary block, plus matching CSS rules in `styles.css` and small copy updates in `index.html`.
- Added server-side-safe helpers and logic in `app.js` for creating today’s challenge (`getDailyChallengeSeed`, `getDailyChallengeTarget`, `ensureDailyChallengeForToday`), tracking streak behaviour, awarding streak-based coin bonuses, updating displayed progress and claiming rewards when the target is met, and syncing the displayed streak when days are missed.
- Updated `AGENTS.md` to instruct the agent to tidy the GitHub issue queue after implementing an item and moved issue `#38` into the Completed list.

### Testing
- Ran a quick syntax check with `node -c app.js` which succeeded.
- Ran the static-site validation with `sh scripts/validate-static-site.sh` which passed.
- Launched a temporary static server and verified the site responded with `python3 -m http.server ...` plus `curl -I` which returned `200 OK`.
- Ran `git diff --check` and static file presence checks as part of the validation script, all of which reported success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0539ce8d883339b62a0dcb6664694)