### PR TITLE
Add prioritised retention issue queue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,12 @@ After implementing an issue, also tidy the GitHub issue queue so the repository 
 
 ### TODO
 
+- [#52 Add weekly ladders and leagues for multi-day retention](https://github.com/Bigalan09/Burohame/issues/52)
+- [#53 Add a mastery track with permanent unlocks](https://github.com/Bigalan09/Burohame/issues/53)
+- [#54 Add contextual one-more-run prompts after game over](https://github.com/Bigalan09/Burohame/issues/54)
+- [#55 Add multi-step quest chains on top of daily missions](https://github.com/Bigalan09/Burohame/issues/55)
+- [#56 Add themed collection sets and album completion goals](https://github.com/Bigalan09/Burohame/issues/56)
+
 ### Completed
 
 - [#38 Add a daily challenge and streak system](https://github.com/Bigalan09/Burohame/issues/38)


### PR DESCRIPTION
## Summary
- open five new GitHub issues for the highest-priority retention features
- update `AGENTS.md` so the TODO queue matches the new issue order
- keep the issue briefs implementation-ready for LLM task runners and aligned with the game's calm, skill-first tone

## Testing
- git diff --check
- gh issue list --state open --limit 10