### PR TITLE
Add new TODO items to AGENTS.md for retention and engagement features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,12 @@ After implementing an issue, also tidy the GitHub issue queue so the repository 
 
 ### TODO
 
+- [#52 Add weekly ladders and leagues for multi-day retention](https://github.com/Bigalan09/Burohame/issues/52)
+- [#53 Add a mastery track with permanent unlocks](https://github.com/Bigalan09/Burohame/issues/53)
+- [#54 Add contextual one-more-run prompts after game over](https://github.com/Bigalan09/Burohame/issues/54)
+- [#55 Add multi-step quest chains on top of daily missions](https://github.com/Bigalan09/Burohame/issues/55)
+- [#56 Add themed collection sets and album completion goals](https://github.com/Bigalan09/Burohame/issues/56)
+
 ### Completed
 
 - [#38 Add a daily challenge and streak system](https://github.com/Bigalan09/Burohame/issues/38)


### PR DESCRIPTION
### Motivation
- Add upcoming retention and engagement work items to the ordered issue queue so implementers can pick the next tasks.

### Description
- Updated `AGENTS.md` to append five new `TODO` entries linking to issues `#52` through `#56` for weekly ladders, a mastery track, one-more-run prompts, multi-step quests, and themed collection sets.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c05b69471c83338ff0e32426ac5aee)