### PR TITLE
Update dashboard hero copy

### DIFF
--- a/app.js
+++ b/app.js
@@ -1972,7 +1972,7 @@ function renderDashboard() {
     if (savedGame?.sessionType === 'daily') {
       intro.textContent = 'Your daily challenge is still waiting.';
     } else {
-      intro.textContent = hasSavedGame ? 'Pick up where you left off.' : 'One tap to start playing.';
+      intro.textContent = hasSavedGame ? 'Pick up where you left off.' : 'boo-roh-hah-meh';
     }
   }
   if (missionCopy) {

--- a/index.html
+++ b/index.html
@@ -20,9 +20,9 @@
       <div class="page-scroll page-scroll--dashboard">
         <header class="page-top page-top--dashboard">
           <div>
-            <p class="page-kicker">Calm arcade puzzle</p>
+            <p class="page-kicker">9×9 block puzzle</p>
             <h1>Burohame</h1>
-            <p class="page-intro" id="dashboard-intro">Start a fresh run.</p>
+            <p class="page-intro" id="dashboard-intro">boo-roh-hah-meh</p>
           </div>
           <a class="icon-btn" href="https://github.com/Bigalan09/Burohame" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository">
             <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">


### PR DESCRIPTION
### Motivation
- Make the dashboard hero copy reflect the game's pronunciation and gameplay by showing the pronunciation and a more accurate kicker label.

### Description
- Replace the header kicker with `9×9 block puzzle` and change the dashboard intro to `boo-roh-hah-meh` in `index.html`, and update the dynamic intro in `app.js` so the same `boo-roh-hah-meh` text is shown when there is no saved run.

### Testing
- Ran `git diff --check` and `node --check app.js` with both checks passing; changes were committed on branch `codex/update-hero-copy` and pushed to `origin`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0e219e7408333b6aee0ddea6d73bb)