### PR TITLE
Clarify Codex Web PR reuse workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,18 @@ When you are asked to make repository changes, follow this sequence unless the u
 3. Run the relevant checks for the changes you made.
 4. Commit your changes with a clear message.
 5. Push the branch to `origin`.
-6. Open a GitHub pull request from your branch to `main` on `origin`.
+6. Reuse the existing GitHub pull request for that branch if one already exists. Only open a new pull request when there is no suitable existing pull request to update.
+
+### Codex Web and cloud PR handling
+
+To avoid duplicate pull requests and UI confusion, use these rules whenever Codex Web or Codex cloud is involved:
+
+- Treat the branch as the source of truth. A branch should map to a single active pull request unless the user explicitly asks for a replacement pull request.
+- Before opening a pull request, check whether `origin` already has an open pull request for the current branch. If it does, update and reuse that pull request instead of creating another one.
+- If Codex Web shows a manual "Create PR" option in the UI, do not create an additional pull request when the branch already has one. Mention that the existing pull request should be reused.
+- If an earlier agent already created a pull request, continue pushing commits to the same branch and keep that pull request as the review thread.
+- Only hand PR creation back to the user when automation cannot complete it. In that case, explicitly say whether an existing pull request already exists and instruct the user to reuse it rather than opening a duplicate.
+- Do not end a task by both creating a pull request yourself and asking the user to create another one from the UI. Choose one path only.
 
 ## Working expectations
 


### PR DESCRIPTION
### Motivation
- Prevent agents from repeatedly creating duplicate pull requests and avoid confusion when Codex Web shows a manual "Create PR" option by making PR reuse behaviour explicit in the repository guidance.

### Description
- Update `AGENTS.md` to change step 6 so agents must reuse an existing pull request for a branch when one already exists and only open a new PR when no suitable existing PR can be updated.
- Add a new `Codex Web and cloud PR handling` section that requires checking `origin` for an open PR for the branch, continuing to push commits to an earlier agent-created PR, avoiding creating an extra PR from the Web UI, and only handing PR creation back to the user when automation cannot complete it.

### Testing
- Ran `git diff --check`, which completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c133284d84833399b3aa71a9cf0299)