### PR TITLE
Simplify the game over summary modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -1957,6 +1957,22 @@ function getCompletedRunObjectives() {
   return RUN_OBJECTIVES.filter(objective => summary.completedObjectiveIds.includes(objective.id));
 }
 
+function setGameOverSummaryView(view = 'main') {
+  const mainPanel = document.getElementById('go-summary-main');
+  const detailsPanel = document.getElementById('go-summary-details');
+  const detailsButton = document.getElementById('btn-gameover-details');
+  if (!mainPanel || !detailsPanel || !detailsButton) return;
+
+  const showDetails = view === 'details';
+  mainPanel.hidden = showDetails;
+  detailsPanel.hidden = !showDetails;
+  detailsButton.setAttribute('aria-expanded', showDetails ? 'true' : 'false');
+
+  if (showDetails) {
+    detailsPanel.scrollTop = 0;
+  }
+}
+
 function renderGameOverSummary() {
   const summary = ensureRunSummary();
   const objectives = getCompletedRunObjectives();
@@ -1972,12 +1988,21 @@ function renderGameOverSummary() {
   const dailyStatus = document.getElementById('go-daily-status');
   const dailyCopy = document.getElementById('go-daily-copy');
   const nextRunButton = document.getElementById('btn-new');
+  const detailNextRunButton = document.getElementById('btn-new-details');
   const dashboardButton = document.getElementById('btn-gameover-dashboard');
+  const secondaryDashboardButton = document.getElementById('btn-gameover-dashboard-secondary');
+  const detailDashboardButton = document.getElementById('btn-gameover-dashboard-details');
 
   document.getElementById('go-score').textContent = String(summary.finalScore);
   document.getElementById('go-best').textContent = String(bestScore);
   document.getElementById('go-coins-earned').textContent = `+${summary.coinsEarned}`;
   document.getElementById('go-coin-total').textContent = String(getCoinBalance());
+  setTextIfPresent('go-detail-coin-total', String(getCoinBalance()));
+  setTextIfPresent('go-detail-regions', String(summary.stats.regionsCleared));
+  setTextIfPresent('go-detail-biggest-clear', String(summary.stats.biggestClear));
+  setTextIfPresent('go-detail-max-combo', `${summary.stats.maxCombo}×`);
+  setTextIfPresent('go-detail-racks', String(summary.stats.racksCompleted));
+  setTextIfPresent('go-detail-coach', summary.stats.coachModeUsed ? 'On' : 'Off');
   objectiveCount.textContent = objectives.length === 1 ? '1 cleared' : `${objectives.length} cleared`;
   if (intro) {
     intro.textContent = isDailyChallengeSession()
@@ -1987,7 +2012,13 @@ function renderGameOverSummary() {
   if (dashboardButton) {
     dashboardButton.setAttribute('aria-label', isDailyChallengeSession() ? 'Back to dashboard from daily challenge summary' : 'Back to dashboard');
   }
-  if (continuePrompt && continueEyebrow && continueTitle && continueCopy && continueMeta && nextRunButton) {
+  if (secondaryDashboardButton) {
+    secondaryDashboardButton.textContent = 'Back to dashboard';
+  }
+  if (detailDashboardButton) {
+    detailDashboardButton.textContent = 'Back to dashboard';
+  }
+  if (continuePrompt && continueEyebrow && continueTitle && continueCopy && continueMeta && nextRunButton && detailNextRunButton) {
     const prompt = summary.continuePrompt;
     continuePrompt.hidden = !prompt;
     if (prompt) {
@@ -1996,14 +2027,22 @@ function renderGameOverSummary() {
       continueCopy.textContent = prompt.copy;
       continueMeta.textContent = prompt.meta;
       nextRunButton.textContent = prompt.buttonLabel;
+      detailNextRunButton.textContent = prompt.buttonLabel;
       nextRunButton.dataset.sessionType = prompt.sessionType || currentSessionType;
       nextRunButton.dataset.promptType = prompt.id || '';
       nextRunButton.dataset.prompted = 'true';
+      detailNextRunButton.dataset.sessionType = prompt.sessionType || currentSessionType;
+      detailNextRunButton.dataset.promptType = prompt.id || '';
+      detailNextRunButton.dataset.prompted = 'true';
     } else {
       nextRunButton.textContent = isDailyChallengeSession() ? 'Try daily again' : 'Start next run';
+      detailNextRunButton.textContent = isDailyChallengeSession() ? 'Try daily again' : 'Start next run';
       nextRunButton.dataset.sessionType = currentSessionType;
       nextRunButton.dataset.promptType = '';
       nextRunButton.dataset.prompted = 'false';
+      detailNextRunButton.dataset.sessionType = currentSessionType;
+      detailNextRunButton.dataset.promptType = '';
+      detailNextRunButton.dataset.prompted = 'false';
     }
   }
 
@@ -2022,6 +2061,7 @@ function renderGameOverSummary() {
   }
 
   renderQuestRunSummary(summary);
+  setGameOverSummaryView('main');
 
   objectivesList.innerHTML = '';
   if (!objectives.length) {
@@ -4666,12 +4706,29 @@ document.getElementById('btn-new').addEventListener('click', () => {
   navigateTo('game');
 });
 
-document.getElementById('btn-gameover-dashboard').addEventListener('click', () => {
+document.getElementById('btn-new-details').addEventListener('click', () => {
+  const button = document.getElementById('btn-new-details');
+  startNewGame({
+    sessionType: button.dataset.sessionType === 'daily' ? 'daily' : 'standard',
+    trigger: button.dataset.prompted === 'true' ? 'prompt' : 'manual',
+    promptType: button.dataset.promptType || '',
+  });
+  navigateTo('game');
+});
+
+function handleGameOverDashboardNavigation() {
   if (ensureRunSummary().continuePrompt?.id) recordOneMoreRunDismissed();
   hideOverlay('ov-gameover');
+  setGameOverSummaryView('main');
   navigateTo('dashboard');
   renderDashboard();
-});
+}
+
+document.getElementById('btn-gameover-dashboard').addEventListener('click', handleGameOverDashboardNavigation);
+document.getElementById('btn-gameover-dashboard-secondary').addEventListener('click', handleGameOverDashboardNavigation);
+document.getElementById('btn-gameover-dashboard-details').addEventListener('click', handleGameOverDashboardNavigation);
+document.getElementById('btn-gameover-details').addEventListener('click', () => setGameOverSummaryView('details'));
+document.getElementById('btn-gameover-details-back').addEventListener('click', () => setGameOverSummaryView('main'));
 
 document.addEventListener('visibilitychange', () => {
   if (document.visibilityState !== 'visible') return;

--- a/index.html
+++ b/index.html
@@ -458,54 +458,94 @@
             <path d="M11.75 4.5L6 10l5.75 5.5" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
         </button>
-        <h2>Game Over</h2>
-        <p class="summary-intro">Your run rewards are ready.</p>
-        <div class="run-summary" aria-label="Run rewards summary">
-          <div class="summary-stat summary-stat--score">
-            <span class="summary-label">Score</span>
-            <strong id="go-score">0</strong>
+        <div class="summary-panel summary-panel--main" id="go-summary-main">
+          <h2>Game over</h2>
+          <p class="summary-intro">Your run rewards are ready.</p>
+          <div class="run-summary" aria-label="Run rewards summary">
+            <div class="summary-stat summary-stat--score">
+              <span class="summary-label">Score</span>
+              <strong id="go-score">0</strong>
+            </div>
+            <div class="summary-stat">
+              <span class="summary-label">Best</span>
+              <strong id="go-best">0</strong>
+            </div>
+            <div class="summary-stat summary-stat--coins summary-stat--wide">
+              <span class="summary-label">Coins this run</span>
+              <strong id="go-coins-earned">0</strong>
+            </div>
           </div>
-          <div class="summary-stat">
-            <span class="summary-label">Best</span>
-            <strong id="go-best">0</strong>
+          <p class="summary-balance">Coin balance <strong id="go-coin-total">0</strong></p>
+          <section class="summary-continue" id="go-continue-prompt" hidden aria-labelledby="go-continue-title">
+            <span class="summary-continue__eyebrow" id="go-continue-eyebrow">One more run</span>
+            <h3 id="go-continue-title">A calm nudge for the next run</h3>
+            <p id="go-continue-copy">You’re close to something meaningful, so the next run is only one tap away.</p>
+            <span class="summary-continue__meta" id="go-continue-meta">Reward · progress nearby</span>
+          </section>
+          <section class="summary-challenge" id="go-daily-summary" hidden>
+            <div class="summary-challenge__head">
+              <h3>Daily challenge</h3>
+              <span id="go-daily-status">In progress</span>
+            </div>
+            <p id="go-daily-copy">Today’s target is still waiting for you.</p>
+          </section>
+          <div class="summary-actions">
+            <button class="pill-btn wide summary-primary-btn" id="btn-new" type="button">Start next run</button>
+            <button class="pill-btn wide pill-btn--secondary" id="btn-gameover-dashboard-secondary" type="button">Back to dashboard</button>
           </div>
-          <div class="summary-stat summary-stat--coins">
-            <span class="summary-label">Coins this run</span>
-            <strong id="go-coins-earned">0</strong>
+          <button class="summary-details-btn" id="btn-gameover-details" type="button" aria-expanded="false" aria-controls="go-summary-details">View run details</button>
+        </div>
+
+        <div class="summary-panel summary-panel--details" id="go-summary-details" hidden>
+          <div class="summary-details__header">
+            <button class="summary-back-btn" id="btn-gameover-details-back" type="button">Back</button>
+            <h3>Run details</h3>
           </div>
-          <div class="summary-stat">
-            <span class="summary-label">Total coins</span>
-            <strong id="go-coin-total">0</strong>
+          <div class="summary-detail-grid" aria-label="Detailed run statistics">
+            <article class="summary-detail-card">
+              <span class="summary-label">Total coins</span>
+              <strong id="go-detail-coin-total">0</strong>
+            </article>
+            <article class="summary-detail-card">
+              <span class="summary-label">Regions cleared</span>
+              <strong id="go-detail-regions">0</strong>
+            </article>
+            <article class="summary-detail-card">
+              <span class="summary-label">Biggest clear</span>
+              <strong id="go-detail-biggest-clear">0</strong>
+            </article>
+            <article class="summary-detail-card">
+              <span class="summary-label">Best combo</span>
+              <strong id="go-detail-max-combo">0</strong>
+            </article>
+            <article class="summary-detail-card">
+              <span class="summary-label">Racks completed</span>
+              <strong id="go-detail-racks">0</strong>
+            </article>
+            <article class="summary-detail-card">
+              <span class="summary-label">Coach mode</span>
+              <strong id="go-detail-coach">Off</strong>
+            </article>
+          </div>
+          <section class="run-objectives" aria-labelledby="go-objectives-title">
+            <div class="run-objectives__header">
+              <h3 id="go-objectives-title">Completed objectives</h3>
+              <span id="go-objective-count" class="run-objectives__count">0 cleared</span>
+            </div>
+            <ul id="go-objectives-list" class="run-objectives__list"></ul>
+          </section>
+          <section class="run-objectives" id="go-quest-summary" aria-labelledby="go-quest-title">
+            <div class="run-objectives__header">
+              <h3 id="go-quest-title">Quest chain progress</h3>
+              <span id="go-quest-count" class="run-objectives__count">0 updated this run</span>
+            </div>
+            <ul id="go-quest-list" class="run-objectives__list"></ul>
+          </section>
+          <div class="summary-actions summary-actions--details">
+            <button class="pill-btn wide summary-primary-btn" id="btn-new-details" type="button">Start next run</button>
+            <button class="pill-btn wide pill-btn--secondary" id="btn-gameover-dashboard-details" type="button">Back to dashboard</button>
           </div>
         </div>
-        <section class="run-objectives" aria-labelledby="go-objectives-title">
-          <div class="run-objectives__header">
-            <h3 id="go-objectives-title">Completed objectives</h3>
-            <span id="go-objective-count" class="run-objectives__count">0 cleared</span>
-          </div>
-          <ul id="go-objectives-list" class="run-objectives__list"></ul>
-        </section>
-        <section class="run-objectives" id="go-quest-summary" aria-labelledby="go-quest-title">
-          <div class="run-objectives__header">
-            <h3 id="go-quest-title">Quest chain progress</h3>
-            <span id="go-quest-count" class="run-objectives__count">0 updated this run</span>
-          </div>
-          <ul id="go-quest-list" class="run-objectives__list"></ul>
-        </section>
-        <section class="summary-continue" id="go-continue-prompt" hidden aria-labelledby="go-continue-title">
-          <span class="summary-continue__eyebrow" id="go-continue-eyebrow">One more run</span>
-          <h3 id="go-continue-title">A calm nudge for the next run</h3>
-          <p id="go-continue-copy">You’re close to something meaningful, so the next run is only one tap away.</p>
-          <span class="summary-continue__meta" id="go-continue-meta">Reward · progress nearby</span>
-        </section>
-        <section class="summary-challenge" id="go-daily-summary" hidden>
-          <div class="summary-challenge__head">
-            <h3>Daily challenge</h3>
-            <span id="go-daily-status">In progress</span>
-          </div>
-          <p id="go-daily-copy">Today’s target is still waiting for you.</p>
-        </section>
-        <button class="pill-btn wide summary-primary-btn" id="btn-new" type="button">Start next run</button>
       </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -1705,6 +1705,10 @@ a.icon-btn { text-decoration: none; }
   text-align: left;
 }
 
+.summary-panel[hidden] {
+  display: none !important;
+}
+
 .summary-close-btn {
   position: absolute;
   top: 14px;
@@ -1730,14 +1734,14 @@ a.icon-btn { text-decoration: none; }
 }
 
 .summary-intro {
-  margin-bottom: 16px;
+  margin-bottom: 14px;
 }
 
 .run-summary {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
-  margin-bottom: 16px;
+  margin-bottom: 12px;
 }
 
 .summary-stat {
@@ -1750,6 +1754,10 @@ a.icon-btn { text-decoration: none; }
 .summary-stat--score,
 .summary-stat--coins {
   background: color-mix(in srgb, var(--accent) 14%, var(--bg));
+}
+
+.summary-stat--wide {
+  grid-column: 1 / -1;
 }
 
 .summary-label {
@@ -1769,8 +1777,23 @@ a.icon-btn { text-decoration: none; }
   color: var(--text);
 }
 
+.summary-balance {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 0;
+  padding: 0 2px;
+  font-size: 13px;
+}
+
+.summary-balance strong {
+  font-size: 18px;
+  color: var(--text);
+}
+
 .run-objectives {
-  margin-top: 4px;
+  margin-top: 16px;
 }
 
 .run-objectives__header {
@@ -1845,13 +1868,12 @@ a.icon-btn { text-decoration: none; }
 }
 
 .summary-primary-btn {
-  margin-top: 16px;
   font-size: 16px;
   padding-block: 14px;
 }
 
 .summary-continue {
-  margin-top: 14px;
+  margin-top: 16px;
   padding: 15px 16px;
   border-radius: 18px;
   background: color-mix(in srgb, var(--accent) 10%, var(--bg));
@@ -1919,6 +1941,78 @@ a.icon-btn { text-decoration: none; }
   margin-bottom: 0;
   font-size: 13px;
   line-height: 1.45;
+}
+
+.summary-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.summary-actions .wide {
+  margin-top: 0;
+}
+
+.summary-details-btn,
+.summary-back-btn {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: color-mix(in srgb, var(--accent-dk) 68%, var(--text));
+  font-size: 13px;
+  font-weight: 700;
+  padding: 6px 2px 0;
+  cursor: pointer;
+}
+
+.summary-details-btn {
+  margin-top: 10px;
+}
+
+.summary-panel--details {
+  padding-top: 8px;
+  max-height: min(72vh, 560px);
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.summary-details__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+
+.summary-details__header h3 {
+  font-size: 18px;
+}
+
+.summary-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.summary-detail-card {
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--accent) 14%, var(--border));
+}
+
+.summary-detail-card strong {
+  display: block;
+  margin-top: 6px;
+  font-size: 19px;
+  line-height: 1.05;
+}
+
+.summary-actions--details {
+  margin-top: 18px;
+  padding-top: 4px;
 }
 
 .missions-head {


### PR DESCRIPTION
### Motivation
- The existing game-over overlay was densely packed with non-scrolling content which made the primary actions (start next run or return to dashboard) hard to reach on small screens. 
- The change moves to progressive disclosure so the main outcomes and actions are immediate, with fuller run statistics available only if the player asks for them.

### Description
- Restructured the overlay HTML into two panels: a compact main view (`#go-summary-main`) and a scrollable details view (`#go-summary-details`), and added new action buttons including `#btn-gameover-details` and `#btn-new-details` in `index.html`.
- Added CSS rules to support the two-panel layout, stacked action buttons, a scrollable details area and compact stat cards in `styles.css`.
- Implemented `setGameOverSummaryView` and wiring in `app.js` to toggle panels, populate detailed stat fields (`go-detail-*`), and keep next-run and dashboard actions synchronised between both views.
- Updated event handlers so the overlay resets to the simple main view when dismissed and both views use the same `startNewGame` behaviour and dashboard navigation handling.

### Testing
- Ran `node --check app.js` to verify JS syntax and it completed successfully.
- Ran `git diff --check` to look for whitespace/merge errors and it passed with no issues.
- Executed a small Python HTML check that verifies the presence of new element IDs and found all required IDs present and no duplicates.
- Performed a repository status check to ensure the modified files are tracked; all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c16d34d354833393974c4d83c19093)