### PR TITLE
Add themed collection album rewards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,10 +40,9 @@ After implementing an issue, also tidy the GitHub issue queue so the repository 
 
 ### TODO
 
-- [#56 Add themed collection sets and album completion goals](https://github.com/Bigalan09/Burohame/issues/56)
-
 ### Completed
 
+- [#56 Add themed collection sets and album completion goals](https://github.com/Bigalan09/Burohame/issues/56)
 - [#55 Add multi-step quest chains on top of daily missions](https://github.com/Bigalan09/Burohame/issues/55)
 - [#54 Add contextual one-more-run prompts after game over](https://github.com/Bigalan09/Burohame/issues/54)
 - [#53 Add a mastery track with permanent unlocks](https://github.com/Bigalan09/Burohame/issues/53)

--- a/app.js
+++ b/app.js
@@ -192,7 +192,7 @@ let dailyChallengeState = {
 const COLOR_NAMES = ['orange','blue','green','purple','red','teal','pink'];
 const PROGRESSION_STORAGE_KEY = 'bst-progression';
 const GAME_SESSION_STORAGE_KEY = 'bst-current-run';
-const PROGRESSION_STATE_VERSION = 7;
+const PROGRESSION_STATE_VERSION = 8;
 const REDUCED_MOTION_QUERY = window.matchMedia('(prefers-reduced-motion: reduce)');
 const DAILY_CHALLENGE_REWARD_BASE = 12;
 const DAILY_CHALLENGE_STREAK_STEP = 2;
@@ -584,42 +584,56 @@ const COSMETIC_CATALOGUE = Object.freeze({
       name: 'Classic',
       description: 'The original polished finish.',
       price: 0,
+      unlockSource: 'default',
     },
     {
       id: 'satin',
       name: 'Satin',
       description: 'Soft rounded edges with a calm sheen.',
       price: scaleShopPrice(60),
+      unlockSource: 'shop',
     },
     {
       id: 'carbon',
       name: 'Carbon',
       description: 'Sharper edges with a grounded board-game feel.',
       price: scaleShopPrice(110),
+      unlockSource: 'shop',
     },
     {
       id: 'prism',
       name: 'Prism',
       description: 'A brighter faceted shine for high-score chasers.',
       price: scaleShopPrice(170),
+      unlockSource: 'shop',
     },
     {
       id: 'velvet',
       name: 'Velvet',
       description: 'A softer matte finish with rounded edges.',
       price: scaleShopPrice(140),
+      unlockSource: 'shop',
     },
     {
       id: 'frost',
       name: 'Frost',
       description: 'Cool highlights and lighter faces for clean boards.',
       price: scaleShopPrice(190),
+      unlockSource: 'shop',
     },
     {
       id: 'ember',
       name: 'Ember',
       description: 'Deeper shadows and hotter highlights for tense runs.',
       price: scaleShopPrice(230),
+      unlockSource: 'shop',
+    },
+    {
+      id: 'heirloom',
+      name: 'Heirloom',
+      description: 'A gallery-grade finish awarded for completing the full core album.',
+      price: 0,
+      unlockSource: 'album',
     },
   ],
 });
@@ -629,6 +643,90 @@ const BLOCK_SKIN_LOOKUP = Object.freeze(
     return acc;
   }, {})
 );
+const COLLECTION_SET_CATALOGUE = Object.freeze([
+  {
+    id: 'sunrise-studio',
+    season: 'Core album · Set 1',
+    title: 'Sunrise Studio',
+    description: 'Warm, playful tones for softer boards and brighter openings.',
+    completionReward: {
+      type: 'badge',
+      id: 'sunrise-studio-badge',
+      name: 'Sunrise ribbon',
+      detail: 'A woven album ribbon for finishing the whole Sunrise Studio set.',
+    },
+    items: [
+      { type: 'colorway', id: 'orange' },
+      { type: 'colorway', id: 'pink' },
+      { type: 'finish', id: 'satin' },
+      { type: 'finish', id: 'velvet' },
+    ],
+  },
+  {
+    id: 'tidal-archive',
+    season: 'Core album · Set 2',
+    title: 'Tidal Archive',
+    description: 'Cool sea-glass palettes and crisp finishes for cleaner sessions.',
+    completionReward: {
+      type: 'badge',
+      id: 'tidal-archive-badge',
+      name: 'Tidal seal',
+      detail: 'A polished seal marking every item in the Tidal Archive set as owned.',
+    },
+    items: [
+      { type: 'colorway', id: 'blue' },
+      { type: 'colorway', id: 'teal' },
+      { type: 'colorway', id: 'random' },
+      { type: 'finish', id: 'frost' },
+      { type: 'finish', id: 'prism' },
+    ],
+  },
+  {
+    id: 'afterglow-arcade',
+    season: 'Core album · Set 3',
+    title: 'Afterglow Arcade',
+    description: 'Bolder evening colours and sharper finishes for dramatic boards.',
+    completionReward: {
+      type: 'badge',
+      id: 'afterglow-arcade-badge',
+      name: 'Afterglow crest',
+      detail: 'A prestige crest that marks the Afterglow Arcade set as complete.',
+    },
+    items: [
+      { type: 'colorway', id: 'green' },
+      { type: 'colorway', id: 'purple' },
+      { type: 'colorway', id: 'red' },
+      { type: 'finish', id: 'carbon' },
+      { type: 'finish', id: 'ember' },
+    ],
+  },
+]);
+const COLLECTION_SET_LOOKUP = Object.freeze(
+  COLLECTION_SET_CATALOGUE.reduce((acc, set) => {
+    acc[set.id] = set;
+    return acc;
+  }, {})
+);
+const COLLECTION_ITEM_TO_SET = Object.freeze(
+  COLLECTION_SET_CATALOGUE.reduce((acc, set) => {
+    set.items.forEach(item => {
+      acc[`${item.type}:${item.id}`] = set.id;
+    });
+    return acc;
+  }, {})
+);
+const COLLECTION_ALBUM_GOAL = Object.freeze({
+  id: 'core-album',
+  title: 'Core album',
+  description: 'Complete every themed set in the core binder to unlock the Heirloom finish.',
+  setIds: COLLECTION_SET_CATALOGUE.map(set => set.id),
+  reward: {
+    type: 'finish',
+    id: 'heirloom',
+    name: 'Heirloom',
+    detail: 'Exclusive finish for completing every themed set in the album.',
+  },
+});
 const RUN_OBJECTIVES = Object.freeze([
   {
     id: 'first-clear',
@@ -878,6 +976,7 @@ function applyWeeklyUnlockReward(reward) {
     }
     return state;
   });
+  evaluateCollectionAlbumRewards();
   updateCosmeticLabel();
 }
 
@@ -1505,6 +1604,7 @@ function createDefaultProgressionState() {
       equippedBlockSkin: 'classic',
       ownedBlockSkins: ['classic'],
       ownedColorways: ['orange'],
+      earnedSetBadges: [],
     },
     dailyMissions: {
       date: '',
@@ -1544,6 +1644,10 @@ function createDefaultProgressionState() {
     },
     questBoard: createDefaultQuestBoardState(),
     weeklyLadder: createDefaultWeeklyLadderState(),
+    collectionAlbum: {
+      completedSetIds: [],
+      claimedGoalIds: [],
+    },
   };
 }
 
@@ -1602,6 +1706,7 @@ function sanitiseProgressionState(rawState) {
   const unlocks = src.unlocks && typeof src.unlocks === 'object' ? src.unlocks : {};
   const cosmetics = src.cosmetics && typeof src.cosmetics === 'object' ? src.cosmetics : {};
   const streak = src.streak && typeof src.streak === 'object' ? src.streak : {};
+  const collectionAlbum = src.collectionAlbum && typeof src.collectionAlbum === 'object' ? src.collectionAlbum : {};
   const ownedThemes = (() => {
     const owned = uniqueStringList(unlocks.ownedThemes, defaults.unlocks.ownedThemes);
     return owned.includes('classic') ? owned : ['classic', ...owned];
@@ -1637,6 +1742,7 @@ function sanitiseProgressionState(rawState) {
       equippedBlockSkin,
       ownedBlockSkins,
       ownedColorways,
+      earnedSetBadges: uniqueStringList(cosmetics.earnedSetBadges, defaults.cosmetics.earnedSetBadges),
     },
     dailyMissions: sanitiseMissionState(src.dailyMissions),
     dailyChallenge: sanitiseDailyChallengeState(src.dailyChallenge),
@@ -1650,6 +1756,12 @@ function sanitiseProgressionState(rawState) {
     oneMoreRun: sanitiseOneMoreRunState(src.oneMoreRun),
     questBoard: sanitiseQuestBoardState(src.questBoard),
     weeklyLadder: sanitiseWeeklyLadderState(src.weeklyLadder),
+    collectionAlbum: {
+      completedSetIds: uniqueStringList(collectionAlbum.completedSetIds, defaults.collectionAlbum.completedSetIds)
+        .filter(id => COLLECTION_SET_LOOKUP[id]),
+      claimedGoalIds: uniqueStringList(collectionAlbum.claimedGoalIds, defaults.collectionAlbum.claimedGoalIds)
+        .filter(id => id === COLLECTION_ALBUM_GOAL.id),
+    },
   };
 }
 
@@ -2099,6 +2211,127 @@ function isColorwayOwned(colorId) {
   return getOwnedColorways().includes(colorId);
 }
 
+function isCollectionItemOwned(item, sourceState = progressionState) {
+  if (!item) return false;
+  if (item.type === 'colorway') return (sourceState?.cosmetics?.ownedColorways || []).includes(item.id);
+  if (item.type === 'finish') return (sourceState?.cosmetics?.ownedBlockSkins || []).includes(item.id);
+  return false;
+}
+
+function getCollectionItemMeta(item) {
+  if (!item) return null;
+  if (item.type === 'colorway') return COLORWAY_LOOKUP[item.id] || null;
+  if (item.type === 'finish') return BLOCK_SKIN_LOOKUP[item.id] || null;
+  return null;
+}
+
+function getCollectionSetForItem(itemType, itemId) {
+  const setId = COLLECTION_ITEM_TO_SET[`${itemType}:${itemId}`];
+  return setId ? COLLECTION_SET_LOOKUP[setId] || null : null;
+}
+
+function getCollectionAlbumStatus(sourceState = progressionState) {
+  const completedSetIds = new Set(sourceState?.collectionAlbum?.completedSetIds || []);
+  const earnedBadgeIds = new Set(sourceState?.cosmetics?.earnedSetBadges || []);
+  const setStatuses = COLLECTION_SET_CATALOGUE.map(set => {
+    const itemStatuses = set.items.map(item => {
+      const meta = getCollectionItemMeta(item);
+      return {
+        ...item,
+        meta,
+        owned: isCollectionItemOwned(item, sourceState),
+      };
+    });
+    const ownedCount = itemStatuses.filter(item => item.owned).length;
+    const totalCount = itemStatuses.length;
+    const missingItems = itemStatuses.filter(item => !item.owned);
+    const isComplete = ownedCount === totalCount;
+    return {
+      set,
+      itemStatuses,
+      ownedCount,
+      totalCount,
+      missingItems,
+      remainingCount: totalCount - ownedCount,
+      isComplete,
+      isRecordedComplete: completedSetIds.has(set.id),
+      rewardEarned: earnedBadgeIds.has(set.completionReward.id),
+    };
+  });
+
+  const completedCount = setStatuses.filter(status => status.isComplete).length;
+  const grandRewardOwned = (sourceState?.cosmetics?.ownedBlockSkins || []).includes(COLLECTION_ALBUM_GOAL.reward.id);
+  const grandRewardClaimed = (sourceState?.collectionAlbum?.claimedGoalIds || []).includes(COLLECTION_ALBUM_GOAL.id);
+  const spotlightSet = setStatuses
+    .filter(status => !status.isComplete)
+    .sort((left, right) => left.remainingCount - right.remainingCount || right.ownedCount - left.ownedCount)[0] || null;
+
+  return {
+    setStatuses,
+    completedCount,
+    totalSets: COLLECTION_SET_CATALOGUE.length,
+    spotlightSet,
+    allSetsComplete: completedCount === COLLECTION_SET_CATALOGUE.length,
+    grandRewardOwned,
+    grandRewardClaimed,
+  };
+}
+
+function evaluateCollectionAlbumRewards() {
+  const status = getCollectionAlbumStatus();
+  const newlyCompletedSets = status.setStatuses.filter(setStatus => setStatus.isComplete && !setStatus.isRecordedComplete);
+  const shouldClaimGrandReward = status.allSetsComplete && !status.grandRewardClaimed;
+
+  if (!newlyCompletedSets.length && !shouldClaimGrandReward) return;
+
+  updateProgressionState(state => {
+    newlyCompletedSets.forEach(setStatus => {
+      if (!state.collectionAlbum.completedSetIds.includes(setStatus.set.id)) {
+        state.collectionAlbum.completedSetIds.push(setStatus.set.id);
+      }
+      const badgeId = setStatus.set.completionReward.id;
+      if (!state.cosmetics.earnedSetBadges.includes(badgeId)) {
+        state.cosmetics.earnedSetBadges.push(badgeId);
+      }
+    });
+
+    if (shouldClaimGrandReward) {
+      if (!state.collectionAlbum.claimedGoalIds.includes(COLLECTION_ALBUM_GOAL.id)) {
+        state.collectionAlbum.claimedGoalIds.push(COLLECTION_ALBUM_GOAL.id);
+      }
+      if (!state.cosmetics.ownedBlockSkins.includes(COLLECTION_ALBUM_GOAL.reward.id)) {
+        state.cosmetics.ownedBlockSkins.push(COLLECTION_ALBUM_GOAL.reward.id);
+      }
+    }
+
+    return state;
+  });
+
+  newlyCompletedSets.forEach(setStatus => {
+    showMilestoneMoment({
+      eyebrow: 'Set complete',
+      title: `${setStatus.set.title} finished`,
+      detail: `${setStatus.set.completionReward.name} earned. ${setStatus.set.completionReward.detail}`,
+      major: true,
+      anchor: '.page-panel--album',
+      announce: `${setStatus.set.title} set complete. ${setStatus.set.completionReward.name} earned.`,
+    });
+  });
+
+  if (shouldClaimGrandReward) {
+    showMilestoneMoment({
+      eyebrow: 'Album complete',
+      title: `${COLLECTION_ALBUM_GOAL.reward.name} unlocked`,
+      detail: COLLECTION_ALBUM_GOAL.reward.detail,
+      major: true,
+      anchor: '.page-panel--album',
+      announce: `${COLLECTION_ALBUM_GOAL.reward.name} finish unlocked for completing the collection album.`,
+    });
+  }
+
+  updateCosmeticLabel();
+}
+
 function sanitiseColorSetting(value) {
   return COLORWAY_LOOKUP[value] ? value : 'orange';
 }
@@ -2131,6 +2364,12 @@ function updateCosmeticLabel() {
 
   const dashboardFinish = document.getElementById('dashboard-finish');
   if (dashboardFinish) dashboardFinish.textContent = skin.name;
+
+  const badgeCount = progressionState?.cosmetics?.earnedSetBadges?.length || 0;
+  const badgeLabel = document.getElementById('dashboard-album-badge');
+  if (badgeLabel) {
+    badgeLabel.textContent = badgeCount ? `${badgeCount} album badge${badgeCount === 1 ? '' : 's'} earned` : 'No album badges yet';
+  }
 
   const colourNote = document.getElementById('page-colour-note');
   if (colourNote) {
@@ -2198,6 +2437,7 @@ function unlockColorway(colorId) {
     anchor: '.page-panel--shop',
     announce: `${colorway.name} colourway unlocked.`,
   });
+  evaluateCollectionAlbumRewards();
   updateCosmeticLabel();
   return true;
 }
@@ -2233,6 +2473,7 @@ function unlockBlockSkin(skinId) {
     anchor: '.collection-head',
     announce: `${skin.name} finish unlocked.`,
   });
+  evaluateCollectionAlbumRewards();
   return true;
 }
 
@@ -2702,7 +2943,7 @@ function getCollectionSubtitle() {
   const ownedCount = getOwnedBlockSkins().length;
   const totalCount = COSMETIC_CATALOGUE.blockSkins.length;
   if (ownedCount === totalCount) return 'Every finish is unlocked and ready to equip.';
-  return `${ownedCount}/${totalCount} finishes owned.`;
+  return `${ownedCount}/${totalCount} finishes owned, including album rewards.`;
 }
 
 function getColorwaySubtitle() {
@@ -2719,28 +2960,94 @@ function getShopActionMarkup({ owned, equipped, canAfford, price, itemId, collec
   if (owned) {
     return `<button class="pill-btn pill-btn--secondary" type="button" data-action="equip" data-item-id="${itemId}" data-collection="${collection}">Equip</button>`;
   }
+  if (!price) {
+    return '<button class="pill-btn pill-btn--secondary" type="button" disabled>Album reward</button>';
+  }
   return `<button class="pill-btn${canAfford ? '' : ' pill-btn--secondary'}" type="button" data-action="unlock" data-item-id="${itemId}" data-collection="${collection}" ${canAfford ? '' : 'disabled'}>Unlock · 🪙 ${price}</button>`;
 }
 
 function renderCosmeticsCollection() {
+  const albumList = document.getElementById('collection-album-list');
+  const albumCount = document.getElementById('collection-album-count');
+  const albumSubtitle = document.getElementById('collection-album-subtitle');
+  const albumSpotlight = document.getElementById('collection-album-spotlight');
+  const albumGoalTitle = document.getElementById('collection-album-goal-title');
+  const albumGoalCopy = document.getElementById('collection-album-goal-copy');
   const finishList = document.getElementById('collection-list');
   const colorwayList = document.getElementById('colorway-list');
   const balance = document.getElementById('collection-balance');
   const finishSubtitle = document.getElementById('collection-subtitle');
   const colorwaySubtitle = document.getElementById('colorway-subtitle');
-  if (!finishList || !colorwayList || !balance || !finishSubtitle || !colorwaySubtitle) return;
+  if (!finishList || !colorwayList || !balance || !finishSubtitle || !colorwaySubtitle || !albumList || !albumCount || !albumSubtitle || !albumSpotlight || !albumGoalTitle || !albumGoalCopy) return;
 
   const coinBalance = getCoinBalance();
   const equippedSkin = getEquippedBlockSkin();
+  const albumStatus = getCollectionAlbumStatus();
   balance.textContent = `🪙 ${coinBalance}`;
   finishSubtitle.textContent = getCollectionSubtitle();
   colorwaySubtitle.textContent = getColorwaySubtitle();
+  albumCount.textContent = `${albumStatus.completedCount}/${albumStatus.totalSets} sets complete`;
+  albumSubtitle.textContent = albumStatus.allSetsComplete
+    ? 'The binder is complete. Your Heirloom finish is ready in the collection below.'
+    : 'Finish themed sets to earn prestige badges, then complete the full binder for an exclusive finish.';
+  albumGoalTitle.textContent = COLLECTION_ALBUM_GOAL.reward.name;
+  albumGoalCopy.textContent = albumStatus.grandRewardOwned
+    ? 'Album reward unlocked and ready to equip from Block finishes.'
+    : `${albumStatus.completedCount}/${albumStatus.totalSets} sets finished. ${COLLECTION_ALBUM_GOAL.description}`;
+  if (albumStatus.spotlightSet) {
+    const nextNames = albumStatus.spotlightSet.missingItems
+      .slice(0, 2)
+      .map(item => item.meta?.name || item.id)
+      .join(' · ');
+    albumSpotlight.textContent = albumStatus.spotlightSet.remainingCount === 1
+      ? `${albumStatus.spotlightSet.set.title} is one item away · ${nextNames}`
+      : `${albumStatus.spotlightSet.set.title} needs ${albumStatus.spotlightSet.remainingCount} more items · ${nextNames}`;
+  } else {
+    albumSpotlight.textContent = 'Every set reward has been banked. Enjoy the complete album.';
+  }
+
+  albumList.innerHTML = '';
+  albumStatus.setStatuses.forEach(setStatus => {
+    const card = document.createElement('article');
+    card.className = `album-card${setStatus.isComplete ? ' album-card--complete' : ''}`;
+    const missingSummary = setStatus.missingItems.length
+      ? `Missing ${setStatus.missingItems.map(item => item.meta?.name || item.id).join(', ')}.`
+      : 'Everything in this set is owned.';
+    const badgeState = setStatus.rewardEarned ? 'Badge earned' : 'Badge waiting';
+    const itemMarkup = setStatus.itemStatuses.map(item => `
+      <li class="album-card__item${item.owned ? ' is-owned' : ''}">
+        <span>${item.meta?.name || item.id}</span>
+        <strong>${item.owned ? 'Owned' : 'Locked'}</strong>
+      </li>
+    `).join('');
+    card.innerHTML = `
+      <div class="album-card__head">
+        <div>
+          <span class="album-card__season">${setStatus.set.season}</span>
+          <h3>${setStatus.set.title}</h3>
+          <p>${setStatus.set.description}</p>
+        </div>
+        <span class="album-card__count">${setStatus.ownedCount}/${setStatus.totalCount}</span>
+      </div>
+      <div class="album-card__reward">
+        <strong>${setStatus.set.completionReward.name}</strong>
+        <span>${badgeState}</span>
+      </div>
+      <ul class="album-card__items">${itemMarkup}</ul>
+      <div class="album-card__footer">
+        <span>${missingSummary}</span>
+        <strong>${setStatus.isComplete ? 'Set complete' : `${setStatus.remainingCount} to go`}</strong>
+      </div>
+    `;
+    albumList.appendChild(card);
+  });
 
   colorwayList.innerHTML = '';
   for (const colorway of COLORWAY_CATALOGUE) {
     const owned = isColorwayOwned(colorway.id);
     const equipped = colorSetting === colorway.id;
     const canAfford = coinBalance >= colorway.price;
+    const set = getCollectionSetForItem('colorway', colorway.id);
     const status = equipped ? 'Equipped' : owned ? 'Unlocked' : 'Locked';
     const stateClass = equipped ? 'is-equipped' : owned ? 'is-unlocked' : 'is-locked';
     const costLabel = colorway.price ? `🪙 ${colorway.price}` : 'Free';
@@ -2763,6 +3070,7 @@ function renderCosmeticsCollection() {
         <div class="cosmetic-card__footer">
           <div class="cosmetic-card__meta">
             <span>${costLabel}</span>
+            ${set ? `<span>${set.title}</span>` : ''}
           </div>
           ${getShopActionMarkup({ owned, equipped, canAfford, price: colorway.price, itemId: colorway.id, collection: 'colorway' })}
         </div>
@@ -2776,6 +3084,7 @@ function renderCosmeticsCollection() {
     const owned = isBlockSkinOwned(skin.id);
     const equipped = equippedSkin === skin.id;
     const canAfford = coinBalance >= skin.price;
+    const set = getCollectionSetForItem('finish', skin.id);
     const card = document.createElement('article');
     card.className = 'cosmetic-card';
     card.dataset.cosmetic = skin.id;
@@ -2801,6 +3110,7 @@ function renderCosmeticsCollection() {
         <div class="cosmetic-card__footer">
           <div class="cosmetic-card__meta">
             <span>${costLabel}</span>
+            <span>${set ? set.title : skin.unlockSource === 'album' ? 'Album grand reward' : 'Core collection'}</span>
           </div>
           ${getShopActionMarkup({ owned, equipped, canAfford, price: skin.price, itemId: skin.id, collection: 'finish' })}
         </div>
@@ -3392,6 +3702,33 @@ function renderWeeklyLadder() {
   }
 }
 
+function renderCollectionAlbumTeaser() {
+  const title = document.getElementById('dashboard-album-title');
+  const copy = document.getElementById('dashboard-album-copy');
+  const progress = document.getElementById('dashboard-album-progress');
+  const reward = document.getElementById('dashboard-album-reward');
+  if (!title || !copy || !progress || !reward) return;
+
+  const albumStatus = getCollectionAlbumStatus();
+  const spotlight = albumStatus.spotlightSet;
+  title.textContent = albumStatus.allSetsComplete
+    ? 'Collection album complete'
+    : spotlight
+      ? spotlight.set.title
+      : 'Collection album';
+  copy.textContent = albumStatus.allSetsComplete
+    ? 'Every themed set is complete. Your Heirloom finish is waiting in the shop collection.'
+    : spotlight && spotlight.remainingCount === 1
+      ? `One more unlock completes ${spotlight.set.title}.`
+      : spotlight
+        ? `${spotlight.remainingCount} more items will finish ${spotlight.set.title}.`
+        : 'Browse themed sets and work towards album rewards.';
+  progress.textContent = `${albumStatus.completedCount}/${albumStatus.totalSets} sets complete`;
+  reward.textContent = albumStatus.grandRewardOwned
+    ? `${COLLECTION_ALBUM_GOAL.reward.name} unlocked`
+    : `Grand reward · ${COLLECTION_ALBUM_GOAL.reward.name}`;
+}
+
 function renderDashboard() {
   const continueBtn = document.getElementById('btn-dashboard-continue');
   const newGameBtn = document.getElementById('btn-dashboard-new');
@@ -3434,6 +3771,7 @@ function renderDashboard() {
   renderDailyMissions();
   renderQuestBoard();
   renderWeeklyLadder();
+  renderCollectionAlbumTeaser();
 }
 
 function populateQuickSettings() {
@@ -4538,6 +4876,9 @@ document.getElementById('btn-dashboard-quests-page').addEventListener('click', (
 document.getElementById('btn-dashboard-missions-page').addEventListener('click', () => {
   navigateTo('missions');
 });
+document.getElementById('btn-dashboard-album-page').addEventListener('click', () => {
+  navigateTo('shop');
+});
 document.getElementById('btn-dashboard-daily-play').addEventListener('click', () => {
   startNewGame({ sessionType: 'daily', resetPromptChain: true });
   navigateTo('game');
@@ -4699,6 +5040,7 @@ function init() {
   todayScore = (td.d === todayKey) ? td.s : 0;
 
   loadProgressionState();
+  evaluateCollectionAlbumRewards();
   ensureDailyMissionsForToday();
   ensureDailyChallengeForToday();
   ensureQuestBoardForCurrentCycle();

--- a/index.html
+++ b/index.html
@@ -62,6 +62,19 @@
           </article>
         </section>
 
+        <button class="album-teaser" id="btn-dashboard-album-page" type="button" aria-label="Open collection album">
+          <div>
+            <span class="album-teaser__kicker">Collection album</span>
+            <strong id="dashboard-album-title">Collection album</strong>
+            <p id="dashboard-album-copy">Browse themed cosmetic sets and track completion rewards.</p>
+          </div>
+          <div class="album-teaser__meta">
+            <span id="dashboard-album-progress">0/0 sets complete</span>
+            <span id="dashboard-album-reward">Grand reward</span>
+            <span id="dashboard-album-badge">No album badges yet</span>
+          </div>
+        </button>
+
         <section class="dashboard-retention" aria-label="Extras">
           <section class="dashboard-challenge" aria-label="Daily challenge status">
             <div class="dashboard-challenge__head">
@@ -308,6 +321,24 @@
         </header>
 
         <div class="page-panel page-panel--shop">
+          <div class="collection-head">
+            <div>
+              <h3>Collection album</h3>
+              <p id="collection-album-subtitle">Finish themed sets to bank prestige rewards.</p>
+            </div>
+            <span class="missions-count" id="collection-album-count">0/0 sets complete</span>
+          </div>
+          <div class="album-goal">
+            <div>
+              <strong id="collection-album-goal-title">Heirloom</strong>
+              <p id="collection-album-goal-copy">Complete the full album to unlock an exclusive finish.</p>
+            </div>
+            <span class="album-goal__spotlight" id="collection-album-spotlight">A featured set will appear here.</span>
+          </div>
+          <div id="collection-album-list" class="album-list" aria-live="polite"></div>
+        </div>
+
+        <div class="page-panel page-panel--shop page-panel--album">
           <div class="collection-head">
             <div>
               <h3>Colourways</h3>

--- a/styles.css
+++ b/styles.css
@@ -80,6 +80,21 @@
                         0 8px 18px rgba(0,0,0,0.26);
 }
 
+[data-cosmetic="heirloom"] {
+  --block-radius: 7px;
+  --block-border: color-mix(in srgb, #f7e2a3 68%, rgba(255,255,255,0.34));
+  --block-board-fill: linear-gradient(145deg, #fff5cf 0%, #eac772 32%, #ba8741 68%, #7b4e1c 100%);
+  --block-piece-fill: linear-gradient(145deg, #fff7dc 0%, #f0d48c 34%, #c79246 70%, #7b4e1c 100%);
+  --block-board-shadow: inset 0 1px 2px rgba(255,255,255,0.5),
+                        inset 0 -1px 2px rgba(64,35,0,0.24);
+  --block-piece-shadow: inset 0 1px 3px rgba(255,255,255,0.54),
+                        inset 0 -1px 2px rgba(65,37,0,0.24),
+                        0 4px 10px rgba(72,44,0,0.18);
+  --block-ghost-shadow: inset 0 1px 4px rgba(255,255,255,0.56),
+                        inset 0 -1px 3px rgba(65,37,0,0.26),
+                        0 8px 18px rgba(72,44,0,0.28);
+}
+
 /* ===== Dark mode ===== */
 [data-theme="dark"] {
   --bg:        #1c1c1e;
@@ -296,6 +311,61 @@ html, body {
 
 .dashboard-retention {
   margin-top: 18px;
+}
+
+.album-teaser {
+  width: 100%;
+  margin-top: 14px;
+  padding: 16px 18px;
+  border-radius: 24px;
+  border: 1px solid color-mix(in srgb, var(--accent) 16%, var(--border));
+  background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 10%, var(--bg-card)) 0%, color-mix(in srgb, var(--accent-hi) 6%, var(--bg-card)) 100%);
+  color: inherit;
+  text-align: left;
+  display: grid;
+  gap: 12px;
+}
+
+.album-teaser__kicker {
+  display: block;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--accent-dk) 62%, var(--text-2));
+}
+
+.album-teaser strong {
+  display: block;
+  margin-top: 6px;
+  font-size: 22px;
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.album-teaser p {
+  margin-top: 8px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-2);
+}
+
+.album-teaser__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.album-teaser__meta span {
+  min-height: 30px;
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--accent) 14%, var(--border));
+  font-size: 12px;
+  font-weight: 700;
 }
 
 .dashboard-section-head {
@@ -2179,6 +2249,162 @@ a.icon-btn { text-decoration: none; }
   gap: 12px;
 }
 
+.album-goal {
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  border-radius: 20px;
+  background: color-mix(in srgb, var(--accent) 6%, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--accent) 14%, var(--border));
+}
+
+.album-goal strong {
+  display: block;
+  font-size: 18px;
+  line-height: 1;
+}
+
+.album-goal p {
+  margin-top: 6px;
+  font-size: 13px;
+  color: var(--text-2);
+}
+
+.album-goal__spotlight {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-card));
+  border: 1px solid color-mix(in srgb, var(--accent) 16%, var(--border));
+  font-size: 12px;
+  font-weight: 700;
+  color: color-mix(in srgb, var(--accent-dk) 70%, var(--text));
+}
+
+.album-list {
+  display: grid;
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.album-card {
+  padding: 15px;
+  border-radius: 22px;
+  border: 1px solid color-mix(in srgb, var(--accent) 14%, var(--border));
+  background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 5%, var(--bg-card)) 0%, color-mix(in srgb, var(--accent-hi) 3%, var(--bg-card)) 100%);
+  display: grid;
+  gap: 12px;
+}
+
+.album-card--complete {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 10%, var(--bg-card)) 0%, color-mix(in srgb, var(--accent-hi) 6%, var(--bg-card)) 100%);
+  border-color: color-mix(in srgb, var(--accent) 24%, var(--border));
+}
+
+.album-card__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.album-card__season {
+  display: block;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--accent-dk) 62%, var(--text-2));
+}
+
+.album-card__head h3 {
+  margin-top: 5px;
+  font-size: 22px;
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.album-card__head p {
+  margin-top: 7px;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text-2);
+}
+
+.album-card__count,
+.album-card__reward {
+  min-height: 34px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 12px;
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--accent) 16%, var(--border));
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.album-card__reward {
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.album-card__reward span {
+  color: var(--text-2);
+}
+
+.album-card__items {
+  list-style: none;
+  display: grid;
+  gap: 8px;
+}
+
+.album-card__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 38px;
+  padding: 8px 10px;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--accent) 4%, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--accent) 10%, var(--border));
+  font-size: 13px;
+}
+
+.album-card__item strong {
+  flex-shrink: 0;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-2);
+}
+
+.album-card__item.is-owned {
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg));
+}
+
+.album-card__item.is-owned strong {
+  color: color-mix(in srgb, var(--accent-dk) 70%, var(--text));
+}
+
+.album-card__footer {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--text-2);
+}
+
+.album-card__footer strong {
+  color: var(--text);
+}
+
 .page-panel--shop + .page-panel--shop {
   margin-top: 14px;
 }
@@ -2269,6 +2495,15 @@ a.icon-btn { text-decoration: none; }
                     0 2px 6px rgba(79,18,0,0.18);
   --preview-radius: 5px;
   --preview-border: color-mix(in srgb, var(--accent-hi) 24%, rgba(255,200,148,0.34));
+}
+
+.cosmetic-card[data-cosmetic="heirloom"] .cosmetic-card__preview {
+  --preview-fill: linear-gradient(145deg, #fff6d8 0%, #efd286 34%, #c89245 70%, #7b4e1c 100%);
+  --preview-shadow: inset 0 1px 3px rgba(255,255,255,0.62),
+                    inset 0 -1px 2px rgba(72,44,0,0.22),
+                    0 3px 7px rgba(72,44,0,0.16);
+  --preview-radius: 8px;
+  --preview-border: color-mix(in srgb, #f6df9d 64%, rgba(255,255,255,0.34));
 }
 
 .cosmetic-card__tile {


### PR DESCRIPTION
## Summary
- add themed cosmetic set data, album completion tracking, and set reward handling for the shop progression flow
- introduce an album-style shop presentation with set progress, missing-item states, and a grand reward finish for completing the full binder
- add a dashboard teaser for near-complete sets and update the issue queue entry for issue #56

## Testing
- node --check app.js
- sh scripts/validate-static-site.sh
- sh scripts/test-validation-portability.sh

Closes #56