### PR TITLE
Include game name in dashboard share message

### DIFF
--- a/app.js
+++ b/app.js
@@ -7225,7 +7225,7 @@ async function shareBurohameApp() {
   const shareUrl = `${window.location.origin}${window.location.pathname}`;
   const sharePayload = {
     title: 'Burohame',
-    text: 'I have been playing this 9×9 puzzle game. Give it a go.',
+    text: 'I have been playing Burohame, this 9×9 puzzle game. Give it a go.',
     url: shareUrl,
   };
 


### PR DESCRIPTION
### Motivation
- Ensure shared messages clearly identify the product by name so recipients immediately know what is being shared.

### Description
- Update the share payload in `shareBurohameApp` (`app.js`) so the publicly visible `text` now reads: "I have been playing Burohame, this 9×9 puzzle game. Give it a go.", leaving the existing `title` and `url` behaviour unchanged.

### Testing
- Ran `node --check app.js` and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc461d067c8333a2af34d22dcd2b79)