### PR TITLE
Clarify main dashboard card titles

### DIFF
--- a/app.js
+++ b/app.js
@@ -4680,7 +4680,7 @@ function renderDailyChallengePanels() {
   const challenge = ensureDailyChallengeForDate(selectedDailyChallengeDateKey);
   const challengeStatus = getDailyChallengeStatus(challenge);
   const isFirstRunExperience = getCompletedRunCount() === 0;
-  const title = getDailyChallengeLabel(challenge.date);
+  const title = 'Daily Challenge';
   const copy = challengeStatus.complete
     ? 'Board cleared. Pick another day or replay this one for practice.'
     : challengeStatus.isHistorical
@@ -5793,7 +5793,7 @@ function renderWeeklyLadder() {
   setTextIfPresent('weekly-page-copy', 'Live standings update this week as players post better single-run scores.');
   setTextIfPresent('weekly-page-score', String(localBestScore));
   setTextIfPresent('weekly-page-rank', liveRank);
-  setTextIfPresent('dashboard-weekly-card-title', 'This week');
+  setTextIfPresent('dashboard-weekly-card-title', 'Leaderboard');
   setTextIfPresent('dashboard-weekly-card-copy', 'Live global leaderboard');
   setTextIfPresent('dashboard-weekly-card-progress', localBestScore > 0 ? `${liveRank} · best ${localBestScore}` : 'Set your first weekly score');
 
@@ -5833,17 +5833,17 @@ function renderDashboardUnlockPreview({ isFirstRunExperience = false } = {}) {
   const albumStatus = getCollectionAlbumStatus();
   const spotlight = albumStatus.spotlightSet;
 
-  let title = 'Next unlock';
+  let title = 'Collections';
   let copy = 'Unlock your first finish reward.';
   let progress = 'Complete your first run';
 
   if (!isFirstRunExperience) {
     if (albumStatus.allSetsComplete) {
-      title = 'Next unlock';
+      title = 'Collections';
       copy = 'Your collection is complete. Try a higher weekly finish for bonus rewards.';
       progress = `${COLLECTION_ALBUM_GOAL.reward.name} unlocked`;
     } else if (spotlight) {
-      title = 'Next unlock';
+      title = 'Collections';
       copy = spotlight.remainingCount === 1
         ? `One more unlock completes ${spotlight.set.title}.`
         : `${spotlight.remainingCount} more unlocks for ${spotlight.set.title}.`;

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
               <strong id="dashboard-best">0</strong>
             </article>
             <article class="dashboard-stat">
-              <span>Today</span>
+              <span>Daily Challenge</span>
               <strong id="dashboard-today">0</strong>
             </article>
           </div>
@@ -77,7 +77,7 @@
 
         <section class="dashboard-focus" aria-label="Today at a glance">
           <article class="focus-card focus-card--daily" aria-label="Daily challenge options">
-            <span class="focus-card__title" id="dashboard-daily-title">Today</span>
+            <span class="focus-card__title" id="dashboard-daily-title">Daily Challenge</span>
             <p class="focus-card__line" id="dashboard-daily-copy">Play today’s board.</p>
             <div class="focus-card__meta">
               <span id="dashboard-daily-progress">Reward: 12 coins</span>
@@ -91,7 +91,7 @@
           </article>
 
           <button class="focus-card" id="btn-dashboard-weekly-page" type="button" aria-label="Open weekly progress">
-            <span class="focus-card__title" id="dashboard-weekly-card-title">This week</span>
+            <span class="focus-card__title" id="dashboard-weekly-card-title">Leaderboard</span>
             <p class="focus-card__line" id="dashboard-weekly-card-copy">One more run could improve your rank.</p>
             <div class="focus-card__meta">
               <span id="dashboard-weekly-card-progress">Complete your first weekly run</span>
@@ -99,8 +99,8 @@
             </div>
           </button>
 
-          <button class="focus-card" id="btn-dashboard-unlock-page" type="button" aria-label="Open next unlock">
-            <span class="focus-card__title" id="dashboard-unlock-title">Next unlock</span>
+          <button class="focus-card" id="btn-dashboard-unlock-page" type="button" aria-label="Open collections">
+            <span class="focus-card__title" id="dashboard-unlock-title">Collections</span>
             <p class="focus-card__line" id="dashboard-unlock-copy">Complete your first run to start unlocking finishes.</p>
             <div class="focus-card__meta">
               <span id="dashboard-unlock-progress">Collection progress starts after your first run</span>


### PR DESCRIPTION
### Motivation
- Make dashboard labels explicitly describe the content so players understand where to go at a glance.
- Replace ambiguous terms with clearer page names so the focus cards read as destinations rather than transient states.
- Ensure runtime updates match the new static labels so the UI remains consistent after rendering.

### Description
- Updated static labels in `index.html` so the progress strip and daily focus card show `Daily Challenge`, the weekly focus card shows `Leaderboard`, and the unlock focus card shows `Collections` with its aria label changed to `Open collections`.
- Aligned runtime text in `app.js` by using the fixed title `Daily Challenge` for the daily panel, `Leaderboard` for the weekly card, and `Collections` for the collection/unlock preview so dynamic updates match the new wording.
- Made no functional changes to game logic or data handling, only visible copy and related title-setting code.
- Files modified: `index.html` and `app.js`.

### Testing
- Ran `node --check app.js` to validate the JavaScript syntax and the check passed.
- No other automated test harness is present in the repository, so no additional automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc7602989c8333b468438c7af5a202)